### PR TITLE
chore: fix deployment pipeline and bump version elements to v0.5.36

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
   "name": "root",
   "private": true,
   "workspaces": {
-    "packages": ["packages/*"],
+    "packages": [
+      "packages/*"
+    ],
     "nohoist": [
       "**/cognito-custom-mail-lambda",
       "**/cognito-custom-mail-lambda/**"
@@ -48,7 +50,6 @@
     "diff": "^4.0.1",
     "express": "^4.17.1",
     "formik": "^2.0.4",
-    "gh-pages": "^2.2.0",
     "graphql": "^14.5.8",
     "graphql-depth-limit": "^1.1.0",
     "graphql-type-json": "^0.3.1",

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reapit/elements",
-  "version": "0.5.35",
+  "version": "0.5.36",
   "description": "A collection of React components and utilities for building apps for Reapit Marketplace",
   "homepage": "https://github.com/reapit/foundations#readme",
   "bugs": {
@@ -38,6 +38,7 @@
     "@types/papaparse": "^5.0.3",
     "bulma": "^0.7.5",
     "formik": "^2.0.4",
+    "gh-pages": "^2.2.0",
     "hardtack": "^4.1.0",
     "himalaya": "^1.1.0",
     "jsonwebtoken": "^8.5.1",


### PR DESCRIPTION
chore: fix deployment pipeline and bump version elements to v0.5.36