### PR TITLE
fix: webpack pipeline cache not working in some cases

### DIFF
--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -52,31 +52,31 @@ jobs:
         uses: actions/cache@v1
         with:
           path: packages/marketplace/.webpack-cache
-          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-${{hashFiles('scripts/webpack/**')}}-marketplace
+          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-${{hashFiles('scripts/webpack/**/*.js')}}-marketplace
 
       - name: Get aml-checklist build cache
         uses: actions/cache@v1
         with:
           path: packages/aml-checklist/.webpack-cache
-          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-${{hashFiles('scripts/webpack/**')}}-aml-checklist
+          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-${{hashFiles('scripts/webpack/**/*.js')}}-aml-checklist
 
       - name: Get geo-diary build cache
         uses: actions/cache@v1
         with:
           path: packages/geo-diary/.webpack-cache
-          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-${{hashFiles('scripts/webpack/**')}}-geo-diary
+          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-${{hashFiles('scripts/webpack/**/*.js')}}-geo-diary
 
       - name: Get lifetime-legal build cache
         uses: actions/cache@v1
         with:
           path: packages/lifetime-legal/.webpack-cache
-          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-${{hashFiles('scripts/webpack/**')}}-lifetime-legal
+          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-${{hashFiles('scripts/webpack/**/*.js')}}-lifetime-legal
 
       - name: Get smb build cache
         uses: actions/cache@v1
         with:
           path: packages/smb/.webpack-cache
-          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-${{hashFiles('scripts/webpack/**')}}-smb
+          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-${{hashFiles('scripts/webpack/**/*.js')}}-smb
       # End cache
 
       - name: Set up workspace experimental

--- a/.github/workflows/release-develop.yml
+++ b/.github/workflows/release-develop.yml
@@ -75,29 +75,28 @@ jobs:
         uses: actions/cache@v1
         with:
           path: packages/marketplace/.webpack-cache
-          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-${{hashFiles('scripts/webpack/**')}}-marketplace
+          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-${{hashFiles('scripts/webpack/**/*.js')}}-marketplace
 
       - name: Write aml-checklist build cache
         uses: actions/cache@v1
         with:
           path: packages/aml-checklist/.webpack-cache
-          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-${{hashFiles('scripts/webpack/**')}}-aml-checklist
+          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-${{hashFiles('scripts/webpack/**/*.js')}}-aml-checklist
 
       - name: Write geo-diary build cache
         uses: actions/cache@v1
         with:
           path: packages/geo-diary/.webpack-cache
-          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-${{hashFiles('scripts/webpack/**')}}-geo-diary
+          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-${{hashFiles('scripts/webpack/**/*.js')}}-geo-diary
 
       - name: Write lifetime-legal build cache
         uses: actions/cache@v1
         with:
           path: packages/lifetime-legal/.webpack-cache
-          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-${{hashFiles('scripts/webpack/**')}}-lifetime-legal
+          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-${{hashFiles('scripts/webpack/**/*.js')}}-lifetime-legal
 
       - name: Write smb build cache
         uses: actions/cache@v1
         with:
           path: packages/smb/.webpack-cache
-          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-${{hashFiles('scripts/webpack/**')}}-smb
-      # End cache
+          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-${{hashFiles('scripts/webpack/**/*.js')}}-smb


### PR DESCRIPTION
Because we're currently generating `.temp` folder inside `scripts/webpack/build-element-scss/` after yarn build, the hash of the folder will not match since the `.temp/index.scss` file is different every time, thus causing cache couldn't be restored.
Fix that by using only `.js` files in` webpack` folder to calculate hash