### PR TITLE
chore: add PLATFORM_API_BASE_URL env to graphql server serverless deploy

### DIFF
--- a/packages/graphql-server/serverless.yml
+++ b/packages/graphql-server/serverless.yml
@@ -24,6 +24,7 @@ provider:
     NODE_ENV: 'production'
     COGNITO_USERPOOL_ID: ${self:custom.env.${file(./yml-helpers.js):provider.stage.uppercase}.COGNITO_USERPOOL_ID}
     MARKETPLACE_API_BASE_URL: ${self:custom.env.${file(./yml-helpers.js):provider.stage.uppercase}.MARKETPLACE_API_BASE_URL}
+    PLATFORM_API_BASE_URL: ${self:custom.env.${file(./yml-helpers.js):provider.stage.uppercase}.PLATFORM_API_BASE_URL}
 
 package:
   individually: true


### PR DESCRIPTION
- Add `PLATFORM_API_BASE_URL` env in serverless deploy