### PR TITLE
chore: #516 fix smb app to structure as convention

### DIFF
--- a/packages/smb/src/constants/__tests__/error-messages.test.ts
+++ b/packages/smb/src/constants/__tests__/error-messages.test.ts
@@ -1,4 +1,4 @@
-import errorMessages from './error-messages'
+import errorMessages from '../error-messages'
 describe('error-messages', () => {
   describe('MINIMUM_CHARACTER_LENGTH', () => {
     it('should run correctly', () => {


### PR DESCRIPTION
chore: #516 fix smb app to structure as convention
- [x] move file errors message test to __tests__ folder