### PR TITLE
chore: graphql server prettier after build:schema

### DIFF
--- a/packages/graphql-server/package.json
+++ b/packages/graphql-server/package.json
@@ -8,7 +8,7 @@
   "author": "reapit global",
   "main": "dist/index.js",
   "scripts": {
-    "build:schema": "node ./scripts/build-schema.js",
+    "build:schema": "node ./scripts/build-schema.js && prettier src/schema.graphql --write",
     "build:prod": "yarn build:schema && cross-env NODE_ENV=production rimraf dist && tsc --p tsconfig.json",
     "build:serverless": "yarn build:schema && serverless webpack --out dist --stage dev",
     "lint": "concurrently \"tsc --noEmit\" \"eslint --cache --ext=ts,js src\"",


### PR DESCRIPTION
Run prettier after generating `schema.graphql`