### PR TITLE
fix: graphql server not detect process.env in local

### DIFF
--- a/packages/graphql-server/package.json
+++ b/packages/graphql-server/package.json
@@ -15,7 +15,7 @@
     "lint:fix": "prettier \"src/**/*.{graphql,gql}\" --write && eslint --cache --ext=ts,js src --fix",
     "release:dev": "yarn build:schema && serverless deploy --stage dev",
     "release:prod": "yarn build:schema && node ../../scripts/release/release-serverless.js graphql-server",
-    "start:dev": "cross-env NODE_ENV=development && cross-env REAPIT_ENV=LOCAL && yarn build:schema && nodemon",
+    "start:dev": "yarn build:schema && cross-env NODE_ENV=development REAPIT_ENV=LOCAL nodemon",
     "start:prod": "node ./dist/app.js",
     "test:ci": "cross-env TZ=UTC jest --ci --colors --coverage --silent --forceExit",
     "test:dev": "cross-env TZ=UTC jest --watch --verbose",


### PR DESCRIPTION
fix `cross-env` not working when chaining `&&`