### PR TITLE
chore: bump elements version 0.5.42

### DIFF
--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reapit/elements",
-  "version": "0.5.41",
+  "version": "0.5.42",
   "description": "A collection of React components and utilities for building apps for Reapit Marketplace",
   "homepage": "https://github.com/reapit/foundations#readme",
   "bugs": {


### PR DESCRIPTION
Bump `@reapit/elements` v0.5.42