### PR TITLE
chore: fix edit release not trigger github action

### DIFF
--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -14,6 +14,7 @@ env:
   SENTRY_AUTH_TOKEN: ${{secrets.SENTRY_AUTH_TOKEN}}
   REAPIT_ENV: PROD
   CI: true
+  GH_PAT: ${{secrets.GH_PAT}}
 
 jobs:
   release_production:

--- a/package.json
+++ b/package.json
@@ -76,7 +76,8 @@
     "react-router": "^5.1.2",
     "react-router-dom": "^5.1.2",
     "redux": "^4.0.4",
-    "redux-saga": "^1.1.3"
+    "redux-saga": "^1.1.3",
+    "yargs": "^15.3.1"
   },
   "devDependencies": {
     "@babel/core": "^7.7.2",

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "build:prod": "concurrently \"cross-env NODE_ENV=production && rimraf dist && tsdx build --format=cjs,esm,umd && rollup -c\" \"cross-env NODE_ENV=production && rimraf public/dist && build-storybook -o public/dist\"",
     "lint": "concurrently \"tsc --noEmit\" \"eslint --cache --ext=ts,tsx,js src\"",
-    "release:prod": "node ../../scripts/release/release-npm.js elements && node ../../scripts/release/release-prod.js elements reapit-elements-prod",
+    "release:prod": "node ../../scripts/release/release-npm.js elements --skip-edit-release-note && node ../../scripts/release/release-prod.js elements reapit-elements-prod",
     "release:dev": "node ../../scripts/release/release-dev.js elements reapit-elements-dev",
     "lint:fix": "eslint --cache --ext=ts,tsx,js src --fix",
     "start:dev": "start-storybook -p 6006",

--- a/scripts/release/release-npm.js
+++ b/scripts/release/release-npm.js
@@ -1,11 +1,15 @@
 #!/usr/bin/env node
 const { getPreviousTag, editReleaseNote, getVersionTag, runCommand } = require('./utils')
 const execSync = require('child_process').execSync
+const yargs = require('yargs')
 
 const releaseNpm = async () => {
   try {
     const [, , ...args] = process.argv
     const packageName = args[0]
+    // if pass --skip-edit-release-note, then skip editReleaseNote
+    // by default it will edit release note
+    const skipEditReleaseNote = yargs.argv.skipEditReleaseNote
     const { version, packageName: packageNameOnTag } = getVersionTag()
 
     if (!packageName) {
@@ -18,6 +22,9 @@ const releaseNpm = async () => {
       execSync(`git config --global user.email "${process.env.GITHUB_ACTOR}@email.com"`)
       execSync(`git config --global user.name "${process.env.GITHUB_ACTOR}"`)
       runCommand('yarn', ['publish'])
+      if (skipEditReleaseNote) {
+        return
+      }
       const previousTag = getPreviousTag({ packageName: packageNameOnTag })
       await editReleaseNote({ packageName: packageNameOnTag, version, previousTag })
     }

--- a/scripts/release/utils.js
+++ b/scripts/release/utils.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 const spawn = require('child_process').spawnSync
 const execSync = require('child_process').execSync
-const Octokit = require('@octokit/rest')
+const { Octokit } = require('@octokit/rest')
 const path = require('path')
 
 const removeUnuseChar = value => {
@@ -122,7 +122,7 @@ monitor: https://sentry.io/organizations/reapit-ltd/projects/`
 const editReleaseNote = async ({ packageName, version, previousTag }) => {
   try {
     const commitLog = runCommand('git', ['log', `${packageName}_${version}...${previousTag}`, '.'])
-    const token = process.env.GITHUB_TOKEN
+    const token = process.env.GH_PAT
     const octokit = new Octokit({ auth: token })
     const latestRelease = await octokit.repos.getReleaseByTag({
       owner: 'reapit',

--- a/yarn.lock
+++ b/yarn.lock
@@ -25912,7 +25912,7 @@ yargs@^14.0.0, yargs@^14.2.2:
     y18n "^4.0.0"
     yargs-parser "^15.0.1"
 
-yargs@^15.0.0:
+yargs@^15.0.0, yargs@^15.3.1:
   version "15.3.1"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.3.1.tgz#9505b472763963e54afe60148ad27a330818e98b"
   integrity sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==


### PR DESCRIPTION
- We need to capture the `release: edited` event, but it's not being triggered when authenticating with `GITHUB_TOKEN` . Use `GH_PAT` (personal access token) instead. As suggested in here:
https://help.github.com/en/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token
- Fix duplicated `_release` like [this](https://github.com/reapit/foundations/releases/tag/elements_v0.5.43) to avoid GitHub action being triggered 2 times