### PR TITLE
fix: add api-version to earch widget components headers

### DIFF
--- a/packages/web-components/src/common/utils/__tests__/get-server-headers.ts
+++ b/packages/web-components/src/common/utils/__tests__/get-server-headers.ts
@@ -10,11 +10,10 @@ describe('getServerHeaders', () => {
     const apiKey = 'SOME_KEY'
     const req = ({
       headers: {
-        ...DEFAULT_HEADERS,
         'x-api-key': apiKey,
       },
     } as unknown) as Request
-    expect(await getServerHeaders(req, PACKAGE_SUFFIXES.SEARCH_WIDGET)).toEqual(req.headers)
+    expect(await getServerHeaders(req, PACKAGE_SUFFIXES.SEARCH_WIDGET)).toEqual({ ...req.headers, ...DEFAULT_HEADERS })
   })
 
   it('should return the correct headers for local development', async () => {

--- a/packages/web-components/src/common/utils/get-server-headers.ts
+++ b/packages/web-components/src/common/utils/get-server-headers.ts
@@ -33,7 +33,10 @@ export const getServerHeaders = async (req: Request, packageSuffix: PACKAGE_SUFF
       }
     }
     // In prod, I just forward the headers from the request that was decorated by the lambda athorizer
-    return req.headers
+    return {
+      ...DEFAULT_HEADERS,
+      ...req.headers,
+    }
   })()
 
   return {


### PR DESCRIPTION
fix: add api-version to earch widget components headers