### PR TITLE
fix: map headers for requestContext from authorizer to header of lambda function

### DIFF
--- a/packages/web-components/serverless.yml
+++ b/packages/web-components/serverless.yml
@@ -59,14 +59,9 @@ functions:
           request:
             parameters:
               headers:
-                api-key: false
+                api-version: false
                 Authorization: false
                 reapit-customer: false
-          authorizer:
-            arn: arn:aws:lambda:eu-west-2:717858862261:function:web-component-authorizer
-            resultTtlInSeconds: 600
-            identitySource: method.request.header.X-Api-Key
-            type: request
       - http:
           path: propertyImages
           method: get
@@ -75,11 +70,6 @@ functions:
           request:
             parameters:
               headers:
-                api-key: false
+                api-version: false
                 Authorization: false
                 reapit-customer: false
-          authorizer:
-            arn: arn:aws:lambda:eu-west-2:717858862261:function:web-component-authorizer
-            resultTtlInSeconds: 600
-            identitySource: method.request.header.X-Api-Key
-            type: request

--- a/packages/web-components/src/common/utils/__tests__/get-server-headers.ts
+++ b/packages/web-components/src/common/utils/__tests__/get-server-headers.ts
@@ -11,9 +11,15 @@ describe('getServerHeaders', () => {
     const req = ({
       headers: {
         'x-api-key': apiKey,
+        authorization: 'Bearer mockAuthorization',
+        'reapit-customer': 'DXX',
       },
     } as unknown) as Request
-    expect(await getServerHeaders(req, PACKAGE_SUFFIXES.SEARCH_WIDGET)).toEqual({ ...req.headers, ...DEFAULT_HEADERS })
+    expect(await getServerHeaders(req, PACKAGE_SUFFIXES.SEARCH_WIDGET)).toEqual({
+      ...DEFAULT_HEADERS,
+      Authorization: 'Bearer mockAuthorization',
+      'reapit-customer': 'DXX',
+    })
   })
 
   it('should return the correct headers for local development', async () => {

--- a/packages/web-components/src/common/utils/fetcher-server.ts
+++ b/packages/web-components/src/common/utils/fetcher-server.ts
@@ -16,12 +16,13 @@ export const fetcher = async <T, B>({
     method,
     body: JSON.stringify(body),
   } as RequestInit)
-
+  console.log('fetcher', { res })
   if (res.ok) {
     try {
       const jsonVal = await res.json()
       return jsonVal as T
     } catch (err) {
+      console.error('fetcher', { err })
       return {} as T
     }
   }

--- a/packages/web-components/src/common/utils/get-server-headers.ts
+++ b/packages/web-components/src/common/utils/get-server-headers.ts
@@ -9,7 +9,7 @@ type Token = {
 export const getServerHeaders = async (req: Request, packageSuffix: PACKAGE_SUFFIXES) => {
   // For local development, I need to get a token from my client secret, in prod, this is added as a
   // header by my lambda authorizer so not required
-  const authHeaders = await (async () => {
+  const generateAuthHeaders = async () => {
     if (process.env.APP_ENV === 'local') {
       const clientId = process.env[`COGNITO_CLIENT_ID_${packageSuffix}`] as string
       const clientSecret = process.env[`COGNITO_CLIENT_SECRET_${packageSuffix}`] as string
@@ -35,9 +35,11 @@ export const getServerHeaders = async (req: Request, packageSuffix: PACKAGE_SUFF
     // In prod, I just forward the headers from the request that was decorated by the lambda athorizer
     return {
       ...DEFAULT_HEADERS,
-      ...req.headers,
+      'reapit-customer': req?.headers?.['reapit-customer'],
+      Authorization: req?.headers?.authorization,
     }
-  })()
+  }
+  const authHeaders = (await generateAuthHeaders()) as { [name: string]: string }
 
   return {
     ...authHeaders,

--- a/packages/web-components/src/search-widget/server/core/__tests__/index.ts
+++ b/packages/web-components/src/search-widget/server/core/__tests__/index.ts
@@ -1,4 +1,5 @@
-import { searchWidgetHandler } from '../index'
+import { APIGatewayProxyEvent, APIGatewayEventRequestContextWithAuthorizer } from 'aws-lambda'
+import { searchWidgetHandler, parseHeadersFromEvent } from '../index'
 
 describe('searchWidgetHandler', () => {
   it('should launch without crashing', async () => {
@@ -7,5 +8,53 @@ describe('searchWidgetHandler', () => {
     } catch (err) {
       expect(err).toBeUndefined()
     }
+  })
+})
+
+describe('parseHeadersFromEvent', () => {
+  const mockEvent = {
+    headers: {
+      Accept: '*/*',
+      'Accept-Encoding': 'gzip, deflate, br',
+      'Cache-Control': 'no-cache',
+      'Content-Type': 'application/json',
+      Host: 'mockHost',
+      'User-Agent': 'PostmanRuntime/7.24.1',
+      'X-Api-Key': '123456',
+      'X-Forwarded-Port': '443',
+      'X-Forwarded-Proto': 'https',
+    },
+    requestContext: {
+      authorizer: {
+        authorization: ' mockAuthorization',
+        'reapit-customer': 'DXX',
+        principalid: 'Allow',
+      },
+    } as APIGatewayEventRequestContextWithAuthorizer<any>,
+    body: '',
+    multiValueHeaders: {},
+    httpMethod: 'GET',
+    isBase64Encoded: false,
+    path: '',
+    pathParameters: {},
+    queryStringParameters: null,
+    multiValueQueryStringParameters: null,
+    stageVariables: null,
+    resource: '',
+  } as APIGatewayProxyEvent
+  const result = parseHeadersFromEvent(mockEvent)
+  expect(result).toEqual({
+    Accept: '*/*',
+    'Accept-Encoding': 'gzip, deflate, br',
+    'Cache-Control': 'no-cache',
+    'Content-Type': 'application/json',
+    Host: 'mockHost',
+    'User-Agent': 'PostmanRuntime/7.24.1',
+    'X-Api-Key': '123456',
+    'X-Forwarded-Port': '443',
+    'X-Forwarded-Proto': 'https',
+    authorization: 'Bearer mockAuthorization',
+    principalid: 'Allow',
+    'reapit-customer': 'DXX',
   })
 })

--- a/packages/web-components/src/search-widget/server/core/index.ts
+++ b/packages/web-components/src/search-widget/server/core/index.ts
@@ -19,4 +19,20 @@ app.use((err: Error, _req: Request, res: Response) => {
 
 const expressApp = serverless(app)
 
-export const searchWidgetHandler = async (event: APIGatewayProxyEvent, context: Context) => expressApp(event, context)
+export const parseHeadersFromEvent = (event: APIGatewayProxyEvent) => {
+  const authorization = event?.requestContext?.authorizer?.authorization?.trim()
+  const newHeaders = {
+    ...event.headers,
+    ...event?.requestContext?.authorizer,
+    authorization: `Bearer ${authorization}`,
+  } as { [name: string]: string }
+  return newHeaders
+}
+
+export const searchWidgetHandler = async (event: APIGatewayProxyEvent, context: Context) => {
+  console.log('searchWidgetHandler', { event, context })
+  const newHeaders = parseHeadersFromEvent(event)
+  event.headers = newHeaders
+  console.log('searchWidgetHandler', { newHeaders })
+  return expressApp(event, context)
+}


### PR DESCRIPTION
Changes:
- Map header from requestContext to header of request
- Remove redundant headers when request to properties services
- Add logger
- Add more test