### PR TITLE
feat: #1120 elements headings font default fallback to roboto

### DIFF
--- a/packages/elements/src/styles/vendor/bulma.scss
+++ b/packages/elements/src/styles/vendor/bulma.scss
@@ -11,9 +11,9 @@
 // Fonts
 $family-primary: 'Roboto', Helvetica, sans-serif;
 
-$title-family: 'Museo Sans W03_700', Helvetica, sans-serif;
+$title-family: 'Museo Sans W03_700', 'Roboto', Helvetica, Arial, sans-serif;
 $title-weight: 700;
-$subtitle-family: 'Museo Sans W03_700', Helvetica, sans-serif;
+$subtitle-family: 'Museo Sans W03_700', 'Roboto', Helvetica, Arial, sans-serif;
 $subtitle-weight: 700;
 
 // Colors


### PR DESCRIPTION
fixes #1120