### PR TITLE
fix: #768 - add spreadsheet classes to purify-css whitelist

### DIFF
--- a/packages/elements/purify-options.js
+++ b/packages/elements/purify-options.js
@@ -25,6 +25,8 @@ module.exports = {
     '*relative*',
     '*capitalize*',
     'mw-100',
+    '.data-grid-container .data-grid .cell .value-viewer',
+    '.data-grid-container .data-grid .cell .data-editor',
   ],
   // Uncomment this line if you want to see the CSS purified from the package
   // rejected: true


### PR DESCRIPTION
# Pull request checklist

## Does this close any currently open issues?

fixes: #768

**Please check if your PR fulfills the following requirements:**

- [ x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ x] Build (`yarn build`) was run locally and any changes were pushed
- [x ] Lint (`yarn lint`) has passed locally and any fixes were made for failures
- [x ] Test (`yarn test`) has passed locally and any fixes were made for failures

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

**Please check the type of change your PR introduces:**

- [x ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

- Goto: `https://dev.smb-app.reapit.cloud/Offices`
- Column `Office Email`, text is overflow 

Issue Number: #768 

## What is the new behavior?
- Goto: `https://dev.smb-app.reapit.cloud/Offices` (after merge master), or LOCAL ENV
- Column `Office Email`, text is not overflow

## Does this introduce a breaking change?

- [ ] Yes
- [x ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
Classes are purged by `purify-css` while building application using `webpack-sass-prod` script
