### PR TITLE
fix: #1392 Hide loader after finishing fetching data in analytics page

### DIFF
--- a/packages/marketplace/src/components/ui/developer-analytics/cost-explorer/cost-explorer-component/cost-explorer-table.tsx
+++ b/packages/marketplace/src/components/ui/developer-analytics/cost-explorer/cost-explorer-component/cost-explorer-table.tsx
@@ -3,7 +3,7 @@ import { formatNumber, formatCurrency } from '@/utils/number-formatter'
 import { Table, Loader } from '@reapit/elements'
 import { useSelector } from 'react-redux'
 import { selectMonthlyBilling, selectMonthlyBillingLoading } from '@/selector/developer'
-import { EndpointBilling } from '@/reducers/developer'
+import { EndpointBilling, MonthlyBilling } from '@/reducers/developer'
 
 export type CostExplorerTableProps = {}
 
@@ -16,6 +16,9 @@ export type TableRow = {
 }
 
 export const prepareTableData = data => {
+  if (!data) {
+    return []
+  }
   const preparedData = data.map(({ requestsByEndpoint, ...row }) => {
     const subRows = requestsByEndpoint.map((request: EndpointBilling) => {
       return {
@@ -35,48 +38,52 @@ interface PrepareTableColumns {
   totalRequests: number
 }
 
-export const prepareTableColumns = ({ totalCost, totalEndpoints, totalRequests }: PrepareTableColumns) => [
-  {
-    Header: 'Resource',
-    accessor: 'serviceName',
-    columnProps: {
-      className: 'capitalize',
-      width: 200,
+export const prepareTableColumns = (monthlyBilling?: MonthlyBilling | null) => {
+  const totalEndpoints = monthlyBilling?.totalEndpoints || 0
+  const totalRequests = monthlyBilling?.totalRequests || 0
+  const totalCost = monthlyBilling?.totalCost || 0
+  return [
+    {
+      Header: 'Resource',
+      accessor: 'serviceName',
+      columnProps: {
+        className: 'capitalize',
+        width: 200,
+      },
+      Footer: 'Total',
     },
-    Footer: 'Total',
-  },
-  {
-    Header: 'Endpoints',
-    accessor: row => {
-      return row.endpointCount && formatNumber(row.endpointCount)
+    {
+      Header: 'Endpoints',
+      accessor: row => {
+        return row.endpointCount && formatNumber(row.endpointCount)
+      },
+      Footer: formatNumber(totalEndpoints),
     },
-    Footer: formatNumber(totalEndpoints),
-  },
-  {
-    Header: 'API Calls',
-    accessor: row => {
-      return row.requestCount && formatNumber(row.requestCount)
+    {
+      Header: 'API Calls',
+      accessor: row => {
+        return row.requestCount && formatNumber(row.requestCount)
+      },
+      Footer: formatNumber(totalRequests),
     },
-    Footer: formatNumber(totalRequests),
-  },
-  {
-    Header: 'Cost',
-    accessor: row => {
-      return row.cost && formatCurrency(row.cost)
+    {
+      Header: 'Cost',
+      accessor: row => {
+        return row.cost && formatCurrency(row.cost)
+      },
+      Footer: formatCurrency(totalCost),
     },
-    Footer: formatCurrency(totalCost),
-  },
-]
+  ]
+}
 
 const CostExplorerTable: React.FC<CostExplorerTableProps> = () => {
   const monthlyBilling = useSelector(selectMonthlyBilling)
   const isLoading = useSelector(selectMonthlyBillingLoading)
 
-  if (isLoading || !monthlyBilling) return <Loader />
+  if (isLoading) return <Loader />
 
-  const { totalCost, totalEndpoints, totalRequests } = monthlyBilling
-  const columns = prepareTableColumns({ totalCost, totalEndpoints, totalRequests })
-  const tableData = prepareTableData(monthlyBilling.requestsByService)
+  const columns = prepareTableColumns(monthlyBilling)
+  const tableData = prepareTableData(monthlyBilling)
 
   return (
     <>

--- a/packages/marketplace/src/reducers/developer.ts
+++ b/packages/marketplace/src/reducers/developer.ts
@@ -112,9 +112,9 @@ export const defaultState: DeveloperState = {
   isVisible: false,
   myIdentity: null,
   billing: null,
-  isServiceChartLoading: true,
+  isServiceChartLoading: false,
   error: null,
-  isMonthlyBillingLoading: true,
+  isMonthlyBillingLoading: false,
   monthlyBilling: null,
   webhookPingTestStatus: null,
 }


### PR DESCRIPTION
# Pull request checklist

## Does this close any currently open issues?

fixes:

**Please check if your PR fulfills the following requirements:**

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`yarn build`) was run locally and any changes were pushed
- [x] Lint (`yarn lint`) has passed locally and any fixes were made for failures
- [x] Test (`yarn test`) has passed locally and any fixes were made for failures

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

**Please check the type of change your PR introduces:**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1392 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Hide loader after successfully fetching data in analytics page

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
Before: 
![Screenshot_2](https://user-images.githubusercontent.com/22409039/83119957-92992680-a0fa-11ea-9791-0464362d6dbb.png)
After:
![Screenshot_1](https://user-images.githubusercontent.com/22409039/83119985-9a58cb00-a0fa-11ea-827f-a8df9cb69d16.png)