### PR TITLE
fix: #1518 description stretching with long text

### DIFF
--- a/packages/elements/src/styles/vendor/pell.scss
+++ b/packages/elements/src/styles/vendor/pell.scss
@@ -22,6 +22,8 @@ $pell-content-padding: 10px !default;
 }
 
 .pell-content {
+  overflow-x: scroll;
+  overflow-wrap: normal;
   outline: none;
   padding: $pell-content-padding;
   min-height: $pell-content-height;

--- a/packages/marketplace/src/components/pages/developer-submit-app/general-information-section.tsx
+++ b/packages/marketplace/src/components/pages/developer-submit-app/general-information-section.tsx
@@ -17,6 +17,7 @@ import linkStyles from '@/styles/elements/link.scss?mod'
 import { useSelector } from 'react-redux'
 import { selectCategories } from '@/selector/app-categories'
 import { CategoryModel } from '@reapit/foundations-ts-definitions'
+import styles from '@/styles/pages/developer-submit-app.scss?mod'
 
 export type GeneralInformationSectionProps = {}
 
@@ -113,7 +114,7 @@ const GeneralInformationSection: React.FC<GeneralInformationSectionProps> = () =
         </GridItem>
       </Grid>
       <Grid>
-        <GridItem>
+        <GridItem className={styles.gridMaxHalfWidth}>
           <TextArea
             id="summary"
             dataTest="submit-app-summary"
@@ -122,8 +123,9 @@ const GeneralInformationSection: React.FC<GeneralInformationSectionProps> = () =
             placeholder={'A short strapline summary for your app listing. Must be between 50 and 150 characters'}
           />
         </GridItem>
-        <GridItem>
+        <GridItem className={styles.gridMaxHalfWidth}>
           <TextAreaEditor
+            containerClass={styles.contentOverflowXScroll}
             id="description"
             actions={[
               'bold',

--- a/packages/marketplace/src/styles/pages/developer-submit-app.scss
+++ b/packages/marketplace/src/styles/pages/developer-submit-app.scss
@@ -1,3 +1,5 @@
+@import '../base/screen-size.scss';
+
 .terms-submit-app {
   height: 100%;
   width: 100%;
@@ -26,4 +28,11 @@
 .footerButtons {
   padding-top: 0.75rem;
   padding-bottom: 0.75rem;
+}
+
+.gridMaxHalfWidth {
+  @include for-tablet-and-desktop {
+    max-width: 50%;
+  }
+  max-width: 100%;
 }


### PR DESCRIPTION
# Pull request checklist

## Does this close any currently open issues?

fixes: #1518 

**Please check if your PR fulfills the following requirements:**

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`yarn build`) was run locally and any changes were pushed
- [x] Lint (`yarn lint`) has passed locally and any fixes were made for failures
- [x] Test (`yarn test`) has passed locally and any fixes were made for failures

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

**Please check the type of change your PR introduces:**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1518
<img width="1434" alt="Screen Shot 2020-06-05 at 16 31 12" src="https://user-images.githubusercontent.com/26746668/83860845-01edc680-a74a-11ea-8fa5-9bb33cf7d9ac.png">


## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Fix stretched description field by scrolling when overflow 
<img width="1440" alt="Screen Shot 2020-06-05 at 16 33 01" src="https://user-images.githubusercontent.com/26746668/83861209-82acc280-a74a-11ea-99d5-9d139d1d307c.png">


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
