### PR TITLE
fix: #1629 geo-diary should not zoom to low when no markers

### DIFF
--- a/packages/elements/src/components/Map/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/elements/src/components/Map/__tests__/__snapshots__/index.tsx.snap
@@ -365,12 +365,20 @@ exports[`Map renderMap should run correctly 1`] = `
                 0,
               ],
               Array [
+                51.507351,
+                -0.127758,
+              ],
+              Array [
                 0,
                 0,
               ],
               Array [
                 0,
                 0,
+              ],
+              Array [
+                51.507351,
+                -0.127758,
               ],
               Array [
                 0,
@@ -394,6 +402,14 @@ exports[`Map renderMap should run correctly 1`] = `
               ],
             ],
             "results": Array [
+              Object {
+                "type": "return",
+                "value": undefined,
+              },
+              Object {
+                "type": "return",
+                "value": undefined,
+              },
               Object {
                 "type": "return",
                 "value": undefined,
@@ -1009,6 +1025,76 @@ exports[`Map renderMap should run correctly 1`] = `
                     "opts": undefined,
                     "panToBounds": [MockFunction panToBounds],
                     "set": [MockFunction set],
+                    "setCenter": [MockFunction setCenter] {
+                      "calls": Array [
+                        Array [
+                          mockConstructor {
+                            "addListener": [MockFunction addListener],
+                            "bindTo": [MockFunction bindTo],
+                            "get": [MockFunction get],
+                            "lat": [MockFunction lat],
+                            "listeners": Object {},
+                            "lng": [MockFunction lng],
+                            "notify": [MockFunction notify],
+                            "set": [MockFunction set],
+                            "setMap": [MockFunction setMap],
+                            "setValues": [MockFunction setValues],
+                            "unbind": [MockFunction unbind],
+                            "unbindAll": [MockFunction unbindAll],
+                          },
+                        ],
+                      ],
+                      "results": Array [
+                        Object {
+                          "type": "return",
+                          "value": undefined,
+                        },
+                      ],
+                    },
+                    "setClickableIcons": [MockFunction setClickableIcons],
+                    "setHeading": [MockFunction setHeading],
+                    "setMapTypeId": [MockFunction setMapTypeId],
+                    "setOptions": [MockFunction setOptions],
+                    "setStreetView": [MockFunction setStreetView],
+                    "setTilt": [MockFunction setTilt],
+                    "setValues": [MockFunction setValues],
+                    "setZoom": [MockFunction setZoom] {
+                      "calls": Array [
+                        Array [
+                          10,
+                        ],
+                      ],
+                      "results": Array [
+                        Object {
+                          "type": "return",
+                          "value": undefined,
+                        },
+                      ],
+                    },
+                    "unbind": [MockFunction unbind],
+                    "unbindAll": [MockFunction unbindAll],
+                  },
+                  "position": Object {
+                    "lat": 0,
+                    "lng": 0,
+                  },
+                },
+              ],
+              Array [
+                Object {
+                  "label": "mock marker",
+                  "map": mockConstructor {
+                    "addListener": [MockFunction addListener],
+                    "bindTo": [MockFunction bindTo],
+                    "fitBounds": [MockFunction fitBounds],
+                    "get": [MockFunction get],
+                    "getBounds": [MockFunction getBounds],
+                    "listeners": Object {},
+                    "mapDiv": undefined,
+                    "notify": [MockFunction notify],
+                    "opts": undefined,
+                    "panToBounds": [MockFunction panToBounds],
+                    "set": [MockFunction set],
                     "setCenter": [MockFunction setCenter],
                     "setClickableIcons": [MockFunction setClickableIcons],
                     "setHeading": [MockFunction setHeading],
@@ -1017,7 +1103,19 @@ exports[`Map renderMap should run correctly 1`] = `
                     "setStreetView": [MockFunction setStreetView],
                     "setTilt": [MockFunction setTilt],
                     "setValues": [MockFunction setValues],
-                    "setZoom": [MockFunction setZoom],
+                    "setZoom": [MockFunction setZoom] {
+                      "calls": Array [
+                        Array [
+                          10,
+                        ],
+                      ],
+                      "results": Array [
+                        Object {
+                          "type": "return",
+                          "value": undefined,
+                        },
+                      ],
+                    },
                     "unbind": [MockFunction unbind],
                     "unbindAll": [MockFunction unbindAll],
                   },
@@ -1045,74 +1143,16 @@ exports[`Map renderMap should run correctly 1`] = `
                     "setCenter": [MockFunction setCenter] {
                       "calls": Array [
                         Array [
-                          undefined,
-                        ],
-                      ],
-                      "results": Array [
-                        Object {
-                          "type": "return",
-                          "value": undefined,
-                        },
-                      ],
-                    },
-                    "setClickableIcons": [MockFunction setClickableIcons],
-                    "setHeading": [MockFunction setHeading],
-                    "setMapTypeId": [MockFunction setMapTypeId],
-                    "setOptions": [MockFunction setOptions],
-                    "setStreetView": [MockFunction setStreetView],
-                    "setTilt": [MockFunction setTilt],
-                    "setValues": [MockFunction setValues],
-                    "setZoom": [MockFunction setZoom],
-                    "unbind": [MockFunction unbind],
-                    "unbindAll": [MockFunction unbindAll],
-                  },
-                  "position": Object {
-                    "lat": 0,
-                    "lng": 0,
-                  },
-                },
-              ],
-              Array [
-                Object {
-                  "label": "mock marker",
-                  "map": mockConstructor {
-                    "addListener": [MockFunction addListener],
-                    "bindTo": [MockFunction bindTo],
-                    "fitBounds": [MockFunction fitBounds] {
-                      "calls": Array [
-                        Array [
                           mockConstructor {
                             "addListener": [MockFunction addListener],
                             "bindTo": [MockFunction bindTo],
-                            "extend": [MockFunction extend] {
-                              "calls": Array [
-                                Array [
-                                  undefined,
-                                ],
-                              ],
-                              "results": Array [
-                                Object {
-                                  "type": "return",
-                                  "value": undefined,
-                                },
-                              ],
-                            },
                             "get": [MockFunction get],
-                            "getCenter": [MockFunction getCenter] {
-                              "calls": Array [
-                                Array [],
-                              ],
-                              "results": Array [
-                                Object {
-                                  "type": "return",
-                                  "value": undefined,
-                                },
-                              ],
-                            },
-                            "getPosition": [MockFunction getPosition],
+                            "lat": [MockFunction lat],
                             "listeners": Object {},
+                            "lng": [MockFunction lng],
                             "notify": [MockFunction notify],
                             "set": [MockFunction set],
+                            "setMap": [MockFunction setMap],
                             "setValues": [MockFunction setValues],
                             "unbind": [MockFunction unbind],
                             "unbindAll": [MockFunction unbindAll],
@@ -1126,15 +1166,6 @@ exports[`Map renderMap should run correctly 1`] = `
                         },
                       ],
                     },
-                    "get": [MockFunction get],
-                    "getBounds": [MockFunction getBounds],
-                    "listeners": Object {},
-                    "mapDiv": undefined,
-                    "notify": [MockFunction notify],
-                    "opts": undefined,
-                    "panToBounds": [MockFunction panToBounds],
-                    "set": [MockFunction set],
-                    "setCenter": [MockFunction setCenter],
                     "setClickableIcons": [MockFunction setClickableIcons],
                     "setHeading": [MockFunction setHeading],
                     "setMapTypeId": [MockFunction setMapTypeId],
@@ -1203,7 +1234,7 @@ exports[`Map renderMap should run correctly 1`] = `
                     "setZoom": [MockFunction setZoom] {
                       "calls": Array [
                         Array [
-                          10,
+                          8,
                         ],
                       ],
                       "results": Array [

--- a/packages/elements/src/components/Map/__tests__/index.tsx
+++ b/packages/elements/src/components/Map/__tests__/index.tsx
@@ -143,7 +143,7 @@ describe('Map', () => {
   })
 
   describe('setZoomAndCenter', () => {
-    it('should run correctly', () => {
+    it('should call fitBounds and setCenter', () => {
       setZoomAndCenter({
         bounds: mockBounds,
         center: undefined,
@@ -156,20 +156,21 @@ describe('Map', () => {
       expect(mockMap.setCenter).toBeCalledWith(mockBounds.getCenter())
     })
 
-    it('should not call setCenter and fitBounds', () => {
+    it('should call setCenter and setZoom and not call fitBounds', () => {
       setZoomAndCenter({
         bounds: mockBounds,
-        center: {},
+        center: { lat: 51.507351, lng: -0.127758 },
         zoom: 10,
         map: mockMap,
         markers: mockMarkers,
         googleMaps: mockGoogleMaps,
       })
-      expect(mockMap.fitBounds).not.toBeCalledWith(mockBounds)
-      expect(mockMap.setCenter).not.toBeCalledWith(mockBounds.getCenter())
+      expect(mockMap.setCenter).toBeCalled()
+      expect(mockMap.setZoom).toBeCalled()
+      expect(mockMap.fitBounds).not.toBeCalled()
     })
 
-    it('should not call fitBounds', () => {
+    it('should call setZoom', () => {
       setZoomAndCenter({
         bounds: mockBounds,
         center: undefined,
@@ -178,33 +179,35 @@ describe('Map', () => {
         markers: mockMarkers,
         googleMaps: mockGoogleMaps,
       })
+      expect(mockMap.setZoom).toBeCalledWith(10)
+      expect(mockMap.setCenter).not.toBeCalledWith(mockBounds.getCenter())
       expect(mockMap.fitBounds).not.toBeCalledWith(mockBounds)
-      expect(mockMap.setCenter).toBeCalledWith(mockBounds.getCenter())
     })
 
-    it('should not call setCenter', () => {
+    it('should call setCenter', () => {
       setZoomAndCenter({
         bounds: mockBounds,
-        center: {},
+        center: { lat: 51.507351, lng: -0.127758 },
         zoom: undefined,
         map: mockMap,
         markers: mockMarkers,
         googleMaps: mockGoogleMaps,
       })
-      expect(mockMap.fitBounds).toBeCalledWith(mockBounds)
-      expect(mockMap.setCenter).not.toBeCalledWith(mockBounds.getCenter())
+      expect(mockMap.setCenter).toBeCalled()
+      expect(mockMap.setZoom).not.toBeCalled()
+      expect(mockMap.fitBounds).not.toBeCalledWith(mockBounds)
     })
 
-    it('should not call setCenter', () => {
+    it('should not setCenter and setZoom for default', () => {
       setZoomAndCenter({
         bounds: mockBounds,
-        center: {},
+        center: undefined,
         zoom: undefined,
         map: mockMap,
         markers: [],
         googleMaps: mockGoogleMaps,
       })
-      expect(mockMap.setZoom).toBeCalledWith(10)
+      expect(mockMap.setZoom).toBeCalledWith(8)
       expect(mockMap.setCenter).toBeCalled()
     })
   })

--- a/packages/elements/src/components/Map/index.tsx
+++ b/packages/elements/src/components/Map/index.tsx
@@ -140,20 +140,29 @@ export const renderDirection = ({
 }
 
 export const setZoomAndCenter = ({ googleMaps, bounds, center, zoom, map, markers }) => {
-  if (!markers || markers.length === 0) {
+  if (zoom && center) {
+    map.setZoom(zoom)
+    map.setCenter(new googleMaps.LatLng(center.lat, center.lng))
+    return
+  }
+  if (zoom) {
+    map.setZoom(zoom)
+    return
+  }
+  if (center?.lat && center?.lng) {
+    map.setCenter(new googleMaps.LatLng(center.lat, center.lng))
+    return
+  }
+  if (markers?.length < 1) {
     const LONDON_LAT_LNG = { lat: 51.507351, lng: -0.127758 }
-    const DEFAULT_ZOOM = 10
+    const DEFAULT_ZOOM = 8
     map.setCenter(new googleMaps.LatLng(LONDON_LAT_LNG.lat, LONDON_LAT_LNG.lng))
     map.setZoom(DEFAULT_ZOOM)
     return
   }
   markers.forEach(marker => bounds.extend(marker.getPosition()))
-  if (!zoom) {
-    map.fitBounds(bounds)
-  }
-  if (!center) {
-    map.setCenter(bounds.getCenter())
-  }
+  map.fitBounds(bounds)
+  map.setCenter(bounds.getCenter())
   return
 }
 


### PR DESCRIPTION
# Pull request checklist

## Does this close any currently open issues?

fixes: #1629 

**Please check if your PR fulfills the following requirements:**

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`yarn build`) was run locally and any changes were pushed
- [x] Lint (`yarn lint`) has passed locally and any fixes were made for failures
- [x] Test (`yarn test`) has passed locally and any fixes were made for failures

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

**Please check the type of change your PR introduces:**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1629 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Change map for set default zoom and set center when no markers
- Change set default zoom to lower

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
