### PR TITLE
feat: #2398 demo embed return value for offer entity

### DIFF
--- a/packages/graphql-server/src/resolvers/offers/types.graphql
+++ b/packages/graphql-server/src/resolvers/offers/types.graphql
@@ -43,7 +43,14 @@ type OfferModel {
   metadata: JSON
   _eTag: String
   _links: JSON
-  _embedded: JSON
+  _embedded: EmbeddedOfferModel
+}
+
+type EmbeddedOfferModel {
+  applicant: ApplicantModel
+  conveyancing: ConveyancingModel
+  property: PropertyModel
+  negotiator: NegotiatorModel
 }
 
 type PagedResultOfferModel {
@@ -53,6 +60,13 @@ type PagedResultOfferModel {
   pageCount: Int
   totalCount: Int
   _links: JSON
+}
+
+enum OfferQueryEmbed {
+  applicant
+  conveyancing
+  property
+  negotiator
 }
 
 type Query {
@@ -71,7 +85,7 @@ type Query {
     dateTo: String
     metadata: [String]
     name: String
-    embed: [String]
+    embed: [OfferQueryEmbed]
   ): PagedResultOfferModel!
 
   GetOfferById(id: String!, embed: [String]): OfferModel!

--- a/packages/graphql-server/src/schema.graphql
+++ b/packages/graphql-server/src/schema.graphql
@@ -308,7 +308,7 @@ type Query {
     dateTo: String
     metadata: [String]
     name: String
-    embed: [String]
+    embed: [OfferEmbed]
   ): PagedResultOfferModel!
   GetOfferById(id: String!, embed: [String]): OfferModel!
   GetOffices(
@@ -1639,7 +1639,14 @@ type OfferModel {
   metadata: JSON
   _eTag: String
   _links: JSON
-  _embedded: JSON
+  _embedded: EmbeddedOfferModel
+}
+
+type EmbeddedOfferModel {
+  applicant: ApplicantModel
+  conveyancing: ConveyancingModel
+  property: PropertyModel
+  negotiator: NegotiatorModel
 }
 
 type PagedResultOfferModel {
@@ -1649,6 +1656,13 @@ type PagedResultOfferModel {
   pageCount: Int
   totalCount: Int
   _links: JSON
+}
+
+enum OfferEmbed {
+  applicant
+  conveyancing
+  property
+  negotiator
 }
 
 type OfficeModel {

--- a/packages/graphql-server/src/schema.graphql
+++ b/packages/graphql-server/src/schema.graphql
@@ -308,7 +308,7 @@ type Query {
     dateTo: String
     metadata: [String]
     name: String
-    embed: [OfferEmbed]
+    embed: [OfferQueryEmbed]
   ): PagedResultOfferModel!
   GetOfferById(id: String!, embed: [String]): OfferModel!
   GetOffices(
@@ -1658,7 +1658,7 @@ type PagedResultOfferModel {
   _links: JSON
 }
 
-enum OfferEmbed {
+enum OfferQueryEmbed {
   applicant
   conveyancing
   property


### PR DESCRIPTION
# Pull request checklist

## Does this close any currently open issues?

fixes: #2398

**Please check if your PR fulfills the following requirements:**

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`yarn build`) was run locally and any changes were pushed
- [x] Lint (`yarn lint`) has passed locally and any fixes were made for failures
- [x] Test (`yarn test`) has passed locally and any fixes were made for failures

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

**Please check the type of change your PR introduces:**

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #2398

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

### Demo return embed for offer entity
Here's an example when querying offer entity `embed` with `applicant` and `conveyancing`. It's in `enum` array type, so that user can't provide an invalid value here
![image](https://user-images.githubusercontent.com/26746668/90860328-007c8380-e3b4-11ea-80af-a617fdf77c1b.png)


If user doesn't provide value in `embed` but still provides value in the return schema, that field will be `null`. For example, the `property` embed below

![image](https://user-images.githubusercontent.com/26746668/90859949-54d33380-e3b3-11ea-8db0-d3c7c6d06bfa.png)
## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
