### PR TITLE
refactor: added http status code enum for human readable status code returns 

### DIFF
--- a/packages/events-service/src/controllers/automation/create.ts
+++ b/packages/events-service/src/controllers/automation/create.ts
@@ -5,6 +5,7 @@ import { logger } from '../../core/logger'
 import { AppRequest } from '../../types/request'
 import { db } from '../../core/db'
 import { AutomationRequiredFields, generateAutomationItem } from '../../schemas/automation.schema'
+import { HttpStatusCodeEnum } from '@/types/http.status.enum'
 
 type Payload = AutomationRequiredFields
 
@@ -16,10 +17,10 @@ export default async (req: AppRequest, res: Response) => {
     logger.info('Create new automation...', { traceId, payload })
 
     if (req.user?.clientCode !== payload.clientCode) {
-      res.status(401)
+      res.status(HttpStatusCodeEnum.UNAUTHORIZED)
       return res.json({
         error: 'Unauthorized',
-        code: 401,
+        code: HttpStatusCodeEnum.UNAUTHORIZED,
       })
     }
 
@@ -35,15 +36,15 @@ export default async (req: AppRequest, res: Response) => {
 
     logger.info('Created automation successfully', { traceId, result })
 
-    res.status(201)
+    res.status(HttpStatusCodeEnum.CREATED)
     return res.json(result)
   } catch (error) {
     logger.error('Error creating automation', stringifyError(error))
 
-    res.status(400)
+    res.status(HttpStatusCodeEnum.BAD_REQUEST)
     res.json({
       error: `Bad request ${error}`,
-      code: 400,
+      code: HttpStatusCodeEnum.BAD_REQUEST,
     })
   }
 }

--- a/packages/events-service/src/controllers/automation/delete.ts
+++ b/packages/events-service/src/controllers/automation/delete.ts
@@ -4,6 +4,7 @@ import { logger } from '../../core/logger'
 import { AppRequest } from '../../types/request'
 import { db } from '../../core/db'
 import { generateAutomationItem } from '../../schemas/automation.schema'
+import { HttpStatusCodeEnum } from '@/types/http.status.enum'
 
 export default async (req: AppRequest, res: Response) => {
   const id = req.params.id as string | undefined
@@ -16,31 +17,31 @@ export default async (req: AppRequest, res: Response) => {
     const result = await db.get(item)
 
     if (result.clientCode !== req.user?.clientCode) {
-      res.status(401)
+      res.status(HttpStatusCodeEnum.UNAUTHORIZED)
       return res.json({
         error: 'Unauthorized',
-        code: 401,
+        code: HttpStatusCodeEnum.UNAUTHORIZED,
       })
     }
 
     await db.delete(item)
 
-    return res.status(204).send()
+    return res.status(HttpStatusCodeEnum.NO_CONTENT).send()
   } catch (error) {
     logger.error('Error retrieving automation', stringifyError(error))
 
     if (error.name === 'ItemNotFoundException') {
-      res.status(200)
+      res.status(HttpStatusCodeEnum.OK)
       return res.json({
         error: `Automation not found for ${id}`,
-        code: 404,
+        code: HttpStatusCodeEnum.NOT_FOUND,
       })
     }
 
-    res.status(400)
+    res.status(HttpStatusCodeEnum.BAD_REQUEST)
     res.json({
       error: `Bad request ${error}`,
-      code: 400,
+      code: HttpStatusCodeEnum.BAD_REQUEST,
     })
   }
 }

--- a/packages/events-service/src/controllers/automation/get.ts
+++ b/packages/events-service/src/controllers/automation/get.ts
@@ -4,6 +4,7 @@ import { logger } from '../../core/logger'
 import { AppRequest } from '../../types/request'
 import { db } from '../../core/db'
 import { generateAutomationItem } from '../../schemas/automation.schema'
+import { HttpStatusCodeEnum } from '@/types/http.status.enum'
 
 export default async (req: AppRequest, res: Response) => {
   const id = req.params.id as string | undefined
@@ -16,30 +17,30 @@ export default async (req: AppRequest, res: Response) => {
     const result = await db.get(itemToGet)
 
     if (result.clientCode !== req.user?.clientCode) {
-      res.status(401)
+      res.status(HttpStatusCodeEnum.UNAUTHORIZED)
       return res.json({
         error: 'Unauthorized',
-        code: 401,
+        code: HttpStatusCodeEnum.UNAUTHORIZED,
       })
     }
 
-    res.status(200)
+    res.status(HttpStatusCodeEnum.OK)
     return res.json(result)
   } catch (error) {
     logger.error('Error retrieving automation', stringifyError(error))
 
     if (error.name === 'ItemNotFoundException') {
-      res.status(200)
+      res.status(HttpStatusCodeEnum.OK)
       return res.json({
         error: `Automation not found for ${id}`,
-        code: 404,
+        code: HttpStatusCodeEnum.NOT_FOUND,
       })
     }
 
-    res.status(400)
+    res.status(HttpStatusCodeEnum.BAD_REQUEST)
     res.json({
       error: `Bad request ${error}`,
-      code: 400,
+      code: HttpStatusCodeEnum.BAD_REQUEST,
     })
   }
 }

--- a/packages/events-service/src/controllers/automation/list.ts
+++ b/packages/events-service/src/controllers/automation/list.ts
@@ -4,6 +4,7 @@ import { logger } from '../../core/logger'
 import { AppRequest } from '../../types/request'
 import { db } from '../../core/db'
 import { Automation } from '../../schemas/automation.schema'
+import { HttpStatusCodeEnum } from '@/types/http.status.enum'
 
 export default async (req: AppRequest, res: Response) => {
   const clientCode = req.query.clientCode as string | undefined
@@ -13,10 +14,10 @@ export default async (req: AppRequest, res: Response) => {
     logger.info('Getting automations by parmeters...', { traceId, clientCode })
 
     if (req.user?.clientCode !== clientCode) {
-      res.status(401)
+      res.status(HttpStatusCodeEnum.UNAUTHORIZED)
       return res.json({
         error: 'Unauthorized',
-        code: 401,
+        code: HttpStatusCodeEnum.UNAUTHORIZED,
       })
     }
 
@@ -31,15 +32,15 @@ export default async (req: AppRequest, res: Response) => {
       responeRecords.push(record)
     }
 
-    res.status(200)
+    res.status(HttpStatusCodeEnum.OK)
     return res.json(responeRecords)
   } catch (error) {
     logger.error('Error retrieving automations', stringifyError(error))
 
-    res.status(400)
+    res.status(HttpStatusCodeEnum.BAD_REQUEST)
     return res.json({
       error: `Bad request ${error}`,
-      code: 400,
+      code: HttpStatusCodeEnum.BAD_REQUEST,
     })
   }
 }

--- a/packages/events-service/src/controllers/automation/update.ts
+++ b/packages/events-service/src/controllers/automation/update.ts
@@ -4,6 +4,7 @@ import { logger } from '../../core/logger'
 import { AppRequest } from '../../types/request'
 import { Automation, generateAutomationItem } from '../../schemas/automation.schema'
 import { db } from '../../core/db'
+import { HttpStatusCodeEnum } from '@/types/http.status.enum'
 
 type Payload = {
   messageChannel?: Automation['messageChannel']
@@ -23,10 +24,10 @@ export default async (req: AppRequest, res: Response) => {
     const retrievedItem = await db.get(itemToGet)
 
     if (retrievedItem.clientCode !== req.user?.clientCode) {
-      res.status(401)
+      res.status(HttpStatusCodeEnum.UNAUTHORIZED)
       return res.json({
         error: 'Unauthorized',
-        code: 401,
+        code: HttpStatusCodeEnum.UNAUTHORIZED,
       })
     }
 
@@ -41,23 +42,23 @@ export default async (req: AppRequest, res: Response) => {
 
     const result = await db.update(itemToUpdate, { onMissing: 'skip' })
 
-    res.status(200)
+    res.status(HttpStatusCodeEnum.OK)
     return res.json(result)
   } catch (error) {
     logger.error('Error updating automation', stringifyError(error))
 
     if (error.name === 'ItemNotFoundException') {
-      res.status(200)
+      res.status(HttpStatusCodeEnum.OK)
       return res.json({
         error: `Automation with ID ${id} not found`,
-        code: 404,
+        code: HttpStatusCodeEnum.NOT_FOUND,
       })
     }
 
-    res.status(400)
+    res.status(HttpStatusCodeEnum.BAD_REQUEST)
     res.json({
       error: `Bad request ${error}`,
-      code: 400,
+      code: HttpStatusCodeEnum.BAD_REQUEST,
     })
   }
 }

--- a/packages/events-service/src/controllers/event-status/create.ts
+++ b/packages/events-service/src/controllers/event-status/create.ts
@@ -5,6 +5,7 @@ import { logger } from '../../core/logger'
 import { AppRequest } from '../../types/request'
 import { db } from '../../core/db'
 import { generateStatusItem } from '../../schemas/event-status.schema'
+import { HttpStatusCodeEnum } from '@/types/http.status.enum'
 
 type Payload = {
   eventId: string
@@ -21,10 +22,10 @@ export default async (req: AppRequest, res: Response) => {
     logger.info('Create new status...', { traceId, payload })
 
     if (req.user?.clientCode !== payload.clientCode) {
-      res.status(401)
+      res.status(HttpStatusCodeEnum.UNAUTHORIZED)
       return res.json({
         error: 'Unauthorized',
-        code: 401,
+        code: HttpStatusCodeEnum.UNAUTHORIZED,
       })
     }
 
@@ -41,23 +42,23 @@ export default async (req: AppRequest, res: Response) => {
 
     logger.info('Created event status successfully', { traceId, result })
 
-    res.status(201)
+    res.status(HttpStatusCodeEnum.CREATED)
     return res.json(result)
   } catch (error) {
     logger.error('Error creating status', stringifyError(error))
 
     if (error.name === 'ConditionalCheckFailedException') {
-      res.status(409)
+      res.status(HttpStatusCodeEnum.CONFLICT)
       return res.json({
         error: `Conflict. Event with eventId ${payload.eventId} already exists`,
-        code: 409,
+        code: HttpStatusCodeEnum.CONFLICT,
       })
     }
 
-    res.status(400)
+    res.status(HttpStatusCodeEnum.BAD_REQUEST)
     res.json({
       error: `Bad request ${error}`,
-      code: 400,
+      code: HttpStatusCodeEnum.BAD_REQUEST,
     })
   }
 }

--- a/packages/events-service/src/controllers/event-status/get.ts
+++ b/packages/events-service/src/controllers/event-status/get.ts
@@ -4,6 +4,7 @@ import { logger } from '../../core/logger'
 import { AppRequest } from '../../types/request'
 import { db } from '../../core/db'
 import { generateStatusItem } from '../../schemas/event-status.schema'
+import { HttpStatusCodeEnum } from '@/types/http.status.enum'
 
 export default async (req: AppRequest, res: Response) => {
   const eventId = req.params.eventId as string | undefined
@@ -16,30 +17,30 @@ export default async (req: AppRequest, res: Response) => {
     const result = await db.get(itemToGet)
 
     if (result.clientCode !== req.user?.clientCode) {
-      res.status(401)
+      res.status(HttpStatusCodeEnum.UNAUTHORIZED)
       return res.json({
         error: 'Unauthorized',
-        code: 401,
+        code: HttpStatusCodeEnum.UNAUTHORIZED,
       })
     }
 
-    res.status(200)
+    res.status(HttpStatusCodeEnum.OK)
     return res.json(result)
   } catch (error) {
     logger.error('Error retrieving status', stringifyError(error))
 
     if (error.name === 'ItemNotFoundException') {
-      res.status(200)
+      res.status(HttpStatusCodeEnum.OK)
       return res.json({
         error: `Status not found for ${eventId}`,
-        code: 404,
+        code: HttpStatusCodeEnum.NOT_FOUND,
       })
     }
 
-    res.status(400)
+    res.status(HttpStatusCodeEnum.BAD_REQUEST)
     res.json({
       error: `Bad request ${error}`,
-      code: 400,
+      code: HttpStatusCodeEnum.BAD_REQUEST,
     })
   }
 }

--- a/packages/events-service/src/controllers/event-status/list.ts
+++ b/packages/events-service/src/controllers/event-status/list.ts
@@ -5,6 +5,7 @@ import { logger } from '../../core/logger'
 import { AppRequest } from '../../types/request'
 import { db } from '../../core/db'
 import { EventStatus } from '../../schemas/event-status.schema'
+import { HttpStatusCodeEnum } from '@/types/http.status.enum'
 
 export default async (req: AppRequest, res: Response) => {
   const dateFrom = req.query.dateFrom as string | undefined
@@ -17,10 +18,10 @@ export default async (req: AppRequest, res: Response) => {
     logger.info('Getting statuses by parmeters...', { traceId, dateFrom, dateTo, clientCode })
 
     if (req.user?.clientCode !== clientCode) {
-      res.status(401)
+      res.status(HttpStatusCodeEnum.UNAUTHORIZED)
       return res.json({
         error: 'Unauthorized',
-        code: 401,
+        code: HttpStatusCodeEnum.UNAUTHORIZED,
       })
     }
 
@@ -46,15 +47,15 @@ export default async (req: AppRequest, res: Response) => {
       responeRecords.push(record)
     }
 
-    res.status(200)
+    res.status(HttpStatusCodeEnum.OK)
     return res.json(responeRecords)
   } catch (error) {
     logger.error('Error retrieving statuses', stringifyError(error))
 
-    res.status(400)
+    res.status(HttpStatusCodeEnum.BAD_REQUEST)
     return res.json({
       error: `Bad request ${error}`,
-      code: 400,
+      code: HttpStatusCodeEnum.BAD_REQUEST,
     })
   }
 }

--- a/packages/events-service/src/controllers/event-status/update.ts
+++ b/packages/events-service/src/controllers/event-status/update.ts
@@ -4,6 +4,7 @@ import { logger } from '../../core/logger'
 import { AppRequest } from '../../types/request'
 import { EventStatus, generateStatusItem } from '../../schemas/event-status.schema'
 import { db } from '../../core/db'
+import { HttpStatusCodeEnum } from '@/types/http.status.enum'
 
 export default async (req: AppRequest, res: Response) => {
   const eventId = req.params.eventId as string | undefined
@@ -17,10 +18,10 @@ export default async (req: AppRequest, res: Response) => {
     const retrievedItem = await db.get(itemToGet)
 
     if (retrievedItem.clientCode !== req.user?.clientCode) {
-      res.status(401)
+      res.status(HttpStatusCodeEnum.UNAUTHORIZED)
       return res.json({
         error: 'Unauthorized',
-        code: 401,
+        code: HttpStatusCodeEnum.UNAUTHORIZED,
       })
     }
 
@@ -29,23 +30,23 @@ export default async (req: AppRequest, res: Response) => {
 
     const result = await db.update(itemToUpdate, { onMissing: 'skip' })
 
-    res.status(200)
+    res.status(HttpStatusCodeEnum.OK)
     return res.json(result)
   } catch (error) {
     logger.error('Error updating status', stringifyError(error))
 
     if (error.name === 'ItemNotFoundException') {
-      res.status(200)
+      res.status(HttpStatusCodeEnum.OK)
       return res.json({
         error: `Status not found for ${eventId}`,
-        code: 404,
+        code: HttpStatusCodeEnum.NOT_FOUND,
       })
     }
 
-    res.status(400)
+    res.status(HttpStatusCodeEnum.BAD_REQUEST)
     res.json({
       error: `Bad request ${error}`,
-      code: 400,
+      code: HttpStatusCodeEnum.BAD_REQUEST,
     })
   }
 }

--- a/packages/events-service/src/controllers/event-status/upsert.ts
+++ b/packages/events-service/src/controllers/event-status/upsert.ts
@@ -6,6 +6,7 @@ import { generateStatusItem } from '../../schemas/event-status.schema'
 import { db } from '../../core/db'
 import createEventStatus from './create'
 import updateStatusById from './update'
+import { HttpStatusCodeEnum } from '@/types/http.status.enum'
 
 export default async (req: AppRequest, res: Response) => {
   const eventId = req.body.eventId as string | undefined
@@ -30,10 +31,10 @@ export default async (req: AppRequest, res: Response) => {
     }
 
     logger.error('Error upserting status', stringifyError(error))
-    res.status(400)
+    res.status(HttpStatusCodeEnum.BAD_REQUEST)
     res.json({
       error: `Bad request ${error}`,
-      code: 400,
+      code: HttpStatusCodeEnum.BAD_REQUEST,
     })
   }
 }

--- a/packages/events-service/src/controllers/event/create.ts
+++ b/packages/events-service/src/controllers/event/create.ts
@@ -7,6 +7,7 @@ import { Automation } from '../../schemas/automation.schema'
 import { generateStatusItem } from '../../schemas/event-status.schema'
 import { AutomationExecution } from '../../services/automation-execution'
 import { Event } from '../../types/event'
+import {HttpStatusCodeEnum} from '@/types/http.status.enum';
 
 type Payload = {
   event: Event
@@ -83,12 +84,12 @@ export default async (req: AppRequest, res: Response) => {
     if (error.name === 'ConditionalCheckFailedException') {
       const msg = `Conflict. Event with eventId ${event.id} has already been received previously`
       logger.error(msg, { traceId })
-      return res.status(409).json({ error: msg, code: 409 })
+      return res.status(HttpStatusCodeEnum.CONFLICT).json({ error: msg, code: HttpStatusCodeEnum.CONFLICT })
     }
 
-    res.status(400).json({
+    res.status(HttpStatusCodeEnum.BAD_REQUEST).json({
       error: `Bad request ${error}`,
-      code: 400,
+      code: HttpStatusCodeEnum.BAD_REQUEST,
     })
   }
 }

--- a/packages/events-service/src/controllers/event/list.ts
+++ b/packages/events-service/src/controllers/event/list.ts
@@ -7,6 +7,7 @@ import { AppRequest, ReqUser } from '../../types/request'
 import { DecoratedEvents } from '../../services/decorated-events'
 import { EventListQuery } from '../../types/event-list-query'
 import { EventStatus } from '../../schemas/event-status.schema'
+import { HttpStatusCodeEnum } from '@/types/http.status.enum'
 
 const getOutstandingEvents = async (query: EventListQuery, user: ReqUser): Promise<EventStatus[]> => {
   if (user?.clientCode !== query.clientCode) {
@@ -60,10 +61,10 @@ export default async (req: AppRequest, res: Response) => {
   } catch (error) {
     logger.error('Error retrieving decorated events', stringifyError(error))
 
-    res.status(400)
+    res.status(HttpStatusCodeEnum.BAD_REQUEST)
     return res.json({
       error: `Bad request ${error}`,
-      code: 400,
+      code: HttpStatusCodeEnum.BAD_REQUEST,
     })
   }
 }

--- a/packages/events-service/src/types/http.status.enum.ts
+++ b/packages/events-service/src/types/http.status.enum.ts
@@ -1,6 +1,7 @@
 export enum HttpStatusCodeEnum {
   OK = 200,
   CREATED = 201,
+  NO_CONTENT = 204,
   BAD_REQUEST = 400,
   UNAUTHORIZED = 401,
   NOT_FOUND = 404,

--- a/packages/events-service/src/types/http.status.enum.ts
+++ b/packages/events-service/src/types/http.status.enum.ts
@@ -1,0 +1,8 @@
+export enum HttpStatusCodeEnum {
+  OK = 200,
+  CREATED = 201,
+  BAD_REQUEST = 400,
+  UNAUTHORIZED = 401,
+  NOT_FOUND = 404,
+  CONFLICT = 409,
+};


### PR DESCRIPTION
Refactor to add http status code enum for human readable status codes on return from res.status etc. Checkout `packages/events-service/src/types/http.status.enum.ts`

Suggestion: 

Use exception classes and middlewares to reduce the need of duplicated conditions such as unauthorized responses. 

Example:

```ts
export class HttpException extends Error {
  constructor(
    readonly statusCode: HttpStatusCodeEnum = HttpStatusCodeEnum.INTERNAL_SERVER_ERROR,
    readonly message?: string,
  ) {
    super(message || statusCode.toString());
  }
}

export class BadRequestException extends HttpException {
  constructor(message?: string) { // Optional message for option of adding `validation errors`
    super(HttpStatusCodeEnum.BAD_REQUEST, message || "Bad Request");
  }
}

export class UnAuthorizedException extends HttpException {
  constructor(message?: string) {
    super(HttpStatusCodeEnum.UNAUTHORIZED, message || "Unauthorized");
  }
}

// Throwing

(req: Request, res: Response): Promise<Response | never> => {
  if (!req.user || req.user?.clientCode !== payload.clientCode) {
    throw new UnAuthorizedException();
  }
}

// Handling
if (error instanceof HttpException) {
  res.status(error.statusCode)
  res.json({error: error.message, code: error.statusCode});
  return res;
}

```
> Didn't have the NPM token to run tests locally 