### PR TITLE
fix: use random id for searchable dropdown item key

### DIFF
--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reapit/elements",
-  "version": "3.7.6",
+  "version": "3.7.7",
   "description": "A collection of React components and utilities for building apps for Reapit Marketplace",
   "homepage": "https://github.com/reapit/foundations#readme",
   "bugs": {

--- a/packages/elements/src/components/searchable-dropdown/__tests__/__snapshots__/searchable-dropdown.test.tsx.snap
+++ b/packages/elements/src/components/searchable-dropdown/__tests__/__snapshots__/searchable-dropdown.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`ControlledSearchableDropdown component should match a snapshot 1`] = `
 <ElSearchableDropdownContainer>
   <input
+    readOnly={true}
     style={
       Object {
         "display": "none",

--- a/packages/elements/src/components/searchable-dropdown/searchable-dropdown.stories.mdx
+++ b/packages/elements/src/components/searchable-dropdown/searchable-dropdown.stories.mdx
@@ -188,4 +188,3 @@ type ObjectType = {
   </Story>
 </Canvas>
 
-<RenderHtmlMarkup component="SearchableDropdown" story="Controlled Usage" />

--- a/packages/elements/src/components/searchable-dropdown/searchable-dropdown.tsx
+++ b/packages/elements/src/components/searchable-dropdown/searchable-dropdown.tsx
@@ -29,6 +29,8 @@ export interface ControlledSearchableDropdownProps<T> extends React.InputHTMLAtt
   icon?: IconNames
 }
 
+const generateRandomId = () => Math.random().toString(36).substring(7)
+
 export const SearchableDropdownControlledInner = <T extends unknown>(
   {
     isResultsListVisible,
@@ -53,7 +55,7 @@ export const SearchableDropdownControlledInner = <T extends unknown>(
     {isResultsListVisible && (
       <ElSearchableDropdownResultsContainer>
         {resultsList.map((result) => (
-          <ElSearchableDropdownResult key={result.label} onClick={() => onResultClick(result)}>
+          <ElSearchableDropdownResult key={generateRandomId()} onClick={() => onResultClick(result)}>
             {result.label}
           </ElSearchableDropdownResult>
         ))}

--- a/packages/elements/src/components/searchable-dropdown/searchable-dropdown.tsx
+++ b/packages/elements/src/components/searchable-dropdown/searchable-dropdown.tsx
@@ -47,7 +47,7 @@ export const SearchableDropdownControlledInner = <T extends unknown>(
   ref: React.ForwardedRef<HTMLInputElement>,
 ) => (
   <ElSearchableDropdownContainer>
-    <input style={{ display: 'none' }} value={selectedValue} ref={ref} />
+    <input style={{ display: 'none' }} readOnly value={selectedValue} ref={ref} />
     <ElSearchableDropdownSearchInputAddOn>
       <Icon icon={icon} />
     </ElSearchableDropdownSearchInputAddOn>

--- a/packages/elements/src/storybook/changelog.stories.mdx
+++ b/packages/elements/src/storybook/changelog.stories.mdx
@@ -14,6 +14,10 @@ We will publish release version history and changes here. Where possible, we wil
 
 Beta versions should be relatively stable but subject to occssional breaking changes.
 
+### **3.7.7 - 7/1/22**
+
+- Fixed duplicate key issue in SearchableDropdown
+
 ### **3.7.6 - 14/12/21**
 
 - Adds new infographic icons to Icon component


### PR DESCRIPTION
Created new function as the storybook one returns a static string if `NODE_ENV === 'test'` which in this case would log the warning again if used in the storybook context

fixes: #5774 


