### PR TITLE
fix: type error in CRA template

### DIFF
--- a/packages/cra-template-foundations/template/src/core/__mocks__/mock-router.tsx
+++ b/packages/cra-template-foundations/template/src/core/__mocks__/mock-router.tsx
@@ -2,7 +2,13 @@ import { RouteComponentProps } from 'react-router'
 import { UnregisterCallback, Href } from 'history'
 
 // This is to mock out the dependencies for react router
-export function getMockRouterProps<P>({ params, search = '' }: { params: P; search: string }) {
+export function getMockRouterProps<P extends { [K in keyof P]?: string | undefined }>({
+  params,
+  search = ''
+}: {
+  params: P
+  search: string 
+}) {
   const location = {
     hash: 'mockHash',
     key: 'mockKey',
@@ -11,7 +17,7 @@ export function getMockRouterProps<P>({ params, search = '' }: { params: P; sear
     state: {},
   }
 
-  const props: RouteComponentProps = {
+  const props: RouteComponentProps<P | {}> = {
     match: {
       isExact: true,
       params: params || {},


### PR DESCRIPTION
…| { [K in keyof P]?: string | undefined; }'.'

# Pull request checklist

**Detail as per issue below (required):**

When generating a new app using the CRA template, you get an error when running `npm run start`
![image](https://user-images.githubusercontent.com/61322528/191757284-4c2250c4-8489-447f-a98f-047f6d88547b.png)

This PR attempts to resolve this (although it might be incorrect)

fixes: `Type '{} | P' does not satisfy the constraint '{} | { [K in keyof P]?: string | undefined; }'`. which is thrown from line 14 of a generated application (`const props: RouteComponentProps<P | {}> = {`)

I'm not a TS developer normally so this fix may be pointless or potentially highly incorrect.

