### PR TITLE
fix: use native token for non-admin MFA requests

### DIFF
--- a/packages/rc-mfa-config/src/components/active-authenticator/delete-authenticator.tsx
+++ b/packages/rc-mfa-config/src/components/active-authenticator/delete-authenticator.tsx
@@ -2,6 +2,7 @@ import React, { FC, useEffect } from 'react'
 import { Button } from '@reapit/elements'
 import { SendFunction, useReapitUpdate, UpdateActionNames, updateActions } from '@reapit/use-reapit-data'
 import { reapitConnectBrowserSession } from '../../core/connect-session'
+import { nativeSessionWrapper } from '../../core/connect-session-native'
 
 interface DeleteAuthenticatorProps {
   authenticatorId?: string
@@ -25,7 +26,7 @@ export const DeleteAuthenticator: FC<DeleteAuthenticatorProps> = ({
   refreshAuthenticators,
 }) => {
   const [deleteAuthenticatorLoading, , deleteAuthenticator, hasDeleted] = useReapitUpdate<void, boolean>({
-    reapitConnectBrowserSession,
+    reapitConnectBrowserSession: nativeSessionWrapper(reapitConnectBrowserSession),
     action: updateActions[UpdateActionNames.deleteUserAuthenticator],
     method: 'DELETE',
     uriParams: {

--- a/packages/rc-mfa-config/src/components/home/index.tsx
+++ b/packages/rc-mfa-config/src/components/home/index.tsx
@@ -34,6 +34,7 @@ import { AuthenticatorModel } from '@reapit/foundations-ts-definitions'
 import { QrCodeVerify } from './qr-code-verify'
 import { ActiveAuthenticator } from '../active-authenticator'
 import { cx } from '@linaria/core'
+import { nativeSessionWrapper } from '../../core/connect-session-native'
 
 export interface CreateAuthenticatorReturnType {
   secret: string
@@ -68,7 +69,7 @@ export const handleRefresh =
   }
 
 export const HomePage: FC = () => {
-  const { connectSession } = useReapitConnect(reapitConnectBrowserSession)
+  const { connectSession } = useReapitConnect(nativeSessionWrapper(reapitConnectBrowserSession))
   const [qrCode, setQrCode] = useState<CreateAuthenticatorReturnType>()
   const email = connectSession?.loginIdentity.email
   const userId = email ? window.btoa(email.toLowerCase()).replace(/=/g, '') : null

--- a/packages/rc-mfa-config/src/components/home/qr-code-verify.tsx
+++ b/packages/rc-mfa-config/src/components/home/qr-code-verify.tsx
@@ -20,6 +20,7 @@ import { yupResolver } from '@hookform/resolvers/yup'
 import { object, string } from 'yup'
 import { cx } from '@linaria/core'
 import { CreateAuthenticatorReturnType } from '.'
+import { nativeSessionWrapper } from '../../core/connect-session-native'
 
 interface QrCodeVerifyProps {
   refreshAuthenticators: () => void
@@ -78,7 +79,7 @@ export const handleRefresh =
   }
 
 export const QrCodeVerify: FC<QrCodeVerifyProps> = ({ refreshAuthenticators, qrCode, setQrCode }) => {
-  const { connectSession } = useReapitConnect(reapitConnectBrowserSession)
+  const { connectSession } = useReapitConnect(nativeSessionWrapper(reapitConnectBrowserSession))
   const { Modal, openModal, closeModal, modalIsOpen } = useModal()
   const canvasRef = useRef<HTMLCanvasElement | null>(null)
   const email = connectSession?.loginIdentity.email

--- a/packages/rc-mfa-config/src/core/connect-session-native.tsx
+++ b/packages/rc-mfa-config/src/core/connect-session-native.tsx
@@ -1,0 +1,51 @@
+import { ReapitConnectBrowserSession } from '@reapit/connect-session'
+import Cookie from 'js-cookie'
+import { getRCConfig } from './connect-session'
+
+const url = getRCConfig().connectOAuthUrl + '/rpt/native'
+
+const tokenCache: Record<string, string> = {}
+
+export const nativeSessionWrapper = (reapitConnectBrowserSession: ReapitConnectBrowserSession) => {
+  if (Cookie.get('mfa_native_token_required') !== 'true') {
+    return reapitConnectBrowserSession
+  }
+
+  let accessToken
+  return {
+    connectSession: async () => {
+      const session = await reapitConnectBrowserSession.connectSession()
+      if (!session) {
+        return session
+      }
+      if (tokenCache[session.idToken]) {
+        accessToken = tokenCache[session.idToken]
+        return {
+          ...session,
+          accessToken,
+        }
+      }
+      const res = await fetch(url, {
+        credentials: 'include',
+        method: 'post',
+        body: JSON.stringify({
+          idToken: session.idToken,
+        }),
+      })
+      if (!res.ok) {
+        const text = await res.text()
+        console.error(new Error(`Native token exchange resulted in ${res.status}: ${text}`))
+        reapitConnectBrowserSession.connectAuthorizeRedirect()
+        return session
+      }
+      const native = await res.json()
+      accessToken = native.accessToken
+      tokenCache[session.idToken] = native.accessToken
+      return {
+        ...session,
+        accessToken,
+      }
+    },
+    accessToken,
+  } as unknown as ReapitConnectBrowserSession
+}

--- a/packages/rc-mfa-config/src/core/connect-session.tsx
+++ b/packages/rc-mfa-config/src/core/connect-session.tsx
@@ -20,7 +20,7 @@ const cookieOverride = (config: ReapitConnectBrowserSessionInitializers): Reapit
   return config
 }
 
-const getRCConfig = (): ReapitConnectBrowserSessionInitializers => {
+export const getRCConfig = (): ReapitConnectBrowserSessionInitializers => {
   if (process.env.domainMappings) {
     const config: DomainMap = JSON.parse(process.env.domainMappings)
     const domainConfig = config[window.location.hostname]


### PR DESCRIPTION
Feature flagged via a cookie set by RC so it won't affect anything until RC's updated to support the endpoint