### PR TITLE
fix: custom mailer - export function arn

### DIFF
--- a/packages/cognito-custom-mail-lambda/serverless.yml
+++ b/packages/cognito-custom-mail-lambda/serverless.yml
@@ -54,8 +54,11 @@ package:
 functions:
   cognitoCustomMailerHandler:
     handler: src/app.cognitoCustomMailerHandler
-    events:
-      - CognitoUserPool:
-        pool: ${self:custom.env.COGNITO_USERPOOL_ID}
-        trigger: CustomMessage
-        existing: true
+
+resources:
+  Outputs:
+    CustomMailerArn:
+      Value: 
+        Ref: cognitoCustomMailerHandler
+      Export:
+          Name: ${self:provider.stage}-CognitoCustomMailerHandlerArn


### PR DESCRIPTION
Instead of hooking it up ourselves, stops us trampling each other.
export name is "$stage-CognitoCustomMailerHandlerArn" e.g. "dev-CognitoCustomMailerHandlerArn" or "production-CognitoCustomMailerHandlerArn"

For #9896 