### PR TITLE
fix: elements app switcher - use prod url in prod

### DIFF
--- a/packages/elements/src/components/nav/nav-responsive.tsx
+++ b/packages/elements/src/components/nav/nav-responsive.tsx
@@ -124,7 +124,7 @@ export const NavResponsiveAppSwitcher: FC<NavResponsiveAppSwitcherProps> = ({ op
   const [appSwitcherOpen, setAppSwitcherOpen] = useState<boolean>(false)
 
   const marketplaceCallback = () => {
-    if (window.location.href.includes('dev') || window.location.href.includes('localhost')) {
+    if (window.location.href.includes('.dev.') || window.location.href.includes('localhost')) {
       window.location.href = 'https://marketplace.dev.paas.reapit.cloud/installed'
     } else {
       window.location.href = 'https://marketplace.reapit.cloud/installed'


### PR DESCRIPTION
This fixes a current issue where if you click "My Installed Apps" on the developer portal in production it takes you to the staging marketplace.

This is because developers.reapit.cloud contains "dev" 

