### PR TITLE
fix: resolves issue with small video thumbnails in helper content

### DIFF
--- a/packages/developer-portal/src/components/apps/new/__tests__/__snapshots__/helper-content.test.tsx.snap
+++ b/packages/developer-portal/src/components/apps/new/__tests__/__snapshots__/helper-content.test.tsx.snap
@@ -35,6 +35,7 @@ exports[`HelperContent should match a snapshot 1`] = `
                 Every developer will have different use cases for our Platform and it is unlikely you will need to use all of the APIs and tooling we provide. However, the starting point for all integrations is to create an ‘App’,
               </mock-styled.p>
               <svg
+                height="100%"
                 width="100%"
               />
             </div>
@@ -80,7 +81,10 @@ exports[`HelperContent should match a snapshot 1`] = `
               >
                 For the greatest integration with our AgencyCloud Desktop CRM, we support the ability to load client-side apps using an internal web browser, inside of the CRM.
               </mock-styled.p>
-              <svg />
+              <svg
+                height="100%"
+                width="100%"
+              />
             </div>
             <div
               class=""
@@ -185,7 +189,10 @@ exports[`HelperContent should match a snapshot 1`] = `
               >
                 It is possible to get up and running with a website feed from the Platform API. You will want to optimise this flow, implementing webhooks and caching however, the below video is our quick start guide.
               </mock-styled.p>
-              <svg />
+              <svg
+                height="100%"
+                width="100%"
+              />
             </div>
             <div
               class=""
@@ -338,7 +345,10 @@ exports[`HelperContent should match a snapshot 1`] = `
             <div
               class="el-mb7"
             >
-              <svg />
+              <svg
+                height="100%"
+                width="100%"
+              />
             </div>
             <div
               class=""
@@ -449,6 +459,7 @@ exports[`HelperContent should match a snapshot 1`] = `
               Every developer will have different use cases for our Platform and it is unlikely you will need to use all of the APIs and tooling we provide. However, the starting point for all integrations is to create an ‘App’,
             </mock-styled.p>
             <svg
+              height="100%"
               width="100%"
             />
           </div>
@@ -494,7 +505,10 @@ exports[`HelperContent should match a snapshot 1`] = `
             >
               For the greatest integration with our AgencyCloud Desktop CRM, we support the ability to load client-side apps using an internal web browser, inside of the CRM.
             </mock-styled.p>
-            <svg />
+            <svg
+              height="100%"
+              width="100%"
+            />
           </div>
           <div
             class=""
@@ -599,7 +613,10 @@ exports[`HelperContent should match a snapshot 1`] = `
             >
               It is possible to get up and running with a website feed from the Platform API. You will want to optimise this flow, implementing webhooks and caching however, the below video is our quick start guide.
             </mock-styled.p>
-            <svg />
+            <svg
+              height="100%"
+              width="100%"
+            />
           </div>
           <div
             class=""
@@ -752,7 +769,10 @@ exports[`HelperContent should match a snapshot 1`] = `
           <div
             class="el-mb7"
           >
-            <svg />
+            <svg
+              height="100%"
+              width="100%"
+            />
           </div>
           <div
             class=""

--- a/packages/developer-portal/src/components/apps/new/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/developer-portal/src/components/apps/new/__tests__/__snapshots__/index.test.tsx.snap
@@ -590,6 +590,7 @@ exports[`AppsNew should match a snapshot 1`] = `
                     Every developer will have different use cases for our Platform and it is unlikely you will need to use all of the APIs and tooling we provide. However, the starting point for all integrations is to create an ‘App’,
                   </mock-styled.p>
                   <svg
+                    height="100%"
                     width="100%"
                   />
                 </div>
@@ -635,7 +636,10 @@ exports[`AppsNew should match a snapshot 1`] = `
                   >
                     For the greatest integration with our AgencyCloud Desktop CRM, we support the ability to load client-side apps using an internal web browser, inside of the CRM.
                   </mock-styled.p>
-                  <svg />
+                  <svg
+                    height="100%"
+                    width="100%"
+                  />
                 </div>
                 <div
                   class=""
@@ -740,7 +744,10 @@ exports[`AppsNew should match a snapshot 1`] = `
                   >
                     It is possible to get up and running with a website feed from the Platform API. You will want to optimise this flow, implementing webhooks and caching however, the below video is our quick start guide.
                   </mock-styled.p>
-                  <svg />
+                  <svg
+                    height="100%"
+                    width="100%"
+                  />
                 </div>
                 <div
                   class=""
@@ -893,7 +900,10 @@ exports[`AppsNew should match a snapshot 1`] = `
                 <div
                   class="el-mb7"
                 >
-                  <svg />
+                  <svg
+                    height="100%"
+                    width="100%"
+                  />
                 </div>
                 <div
                   class=""
@@ -1601,6 +1611,7 @@ exports[`AppsNew should match a snapshot 1`] = `
                   Every developer will have different use cases for our Platform and it is unlikely you will need to use all of the APIs and tooling we provide. However, the starting point for all integrations is to create an ‘App’,
                 </mock-styled.p>
                 <svg
+                  height="100%"
                   width="100%"
                 />
               </div>
@@ -1646,7 +1657,10 @@ exports[`AppsNew should match a snapshot 1`] = `
                 >
                   For the greatest integration with our AgencyCloud Desktop CRM, we support the ability to load client-side apps using an internal web browser, inside of the CRM.
                 </mock-styled.p>
-                <svg />
+                <svg
+                  height="100%"
+                  width="100%"
+                />
               </div>
               <div
                 class=""
@@ -1751,7 +1765,10 @@ exports[`AppsNew should match a snapshot 1`] = `
                 >
                   It is possible to get up and running with a website feed from the Platform API. You will want to optimise this flow, implementing webhooks and caching however, the below video is our quick start guide.
                 </mock-styled.p>
-                <svg />
+                <svg
+                  height="100%"
+                  width="100%"
+                />
               </div>
               <div
                 class=""
@@ -1904,7 +1921,10 @@ exports[`AppsNew should match a snapshot 1`] = `
               <div
                 class="el-mb7"
               >
-                <svg />
+                <svg
+                  height="100%"
+                  width="100%"
+                />
               </div>
               <div
                 class=""
@@ -2678,6 +2698,7 @@ exports[`AppsNew should match snapshot for mobile view 1`] = `
                     Every developer will have different use cases for our Platform and it is unlikely you will need to use all of the APIs and tooling we provide. However, the starting point for all integrations is to create an ‘App’,
                   </mock-styled.p>
                   <svg
+                    height="100%"
                     width="100%"
                   />
                 </div>
@@ -2723,7 +2744,10 @@ exports[`AppsNew should match snapshot for mobile view 1`] = `
                   >
                     For the greatest integration with our AgencyCloud Desktop CRM, we support the ability to load client-side apps using an internal web browser, inside of the CRM.
                   </mock-styled.p>
-                  <svg />
+                  <svg
+                    height="100%"
+                    width="100%"
+                  />
                 </div>
                 <div
                   class=""
@@ -2828,7 +2852,10 @@ exports[`AppsNew should match snapshot for mobile view 1`] = `
                   >
                     It is possible to get up and running with a website feed from the Platform API. You will want to optimise this flow, implementing webhooks and caching however, the below video is our quick start guide.
                   </mock-styled.p>
-                  <svg />
+                  <svg
+                    height="100%"
+                    width="100%"
+                  />
                 </div>
                 <div
                   class=""
@@ -2981,7 +3008,10 @@ exports[`AppsNew should match snapshot for mobile view 1`] = `
                 <div
                   class="el-mb7"
                 >
-                  <svg />
+                  <svg
+                    height="100%"
+                    width="100%"
+                  />
                 </div>
                 <div
                   class=""
@@ -3689,6 +3719,7 @@ exports[`AppsNew should match snapshot for mobile view 1`] = `
                   Every developer will have different use cases for our Platform and it is unlikely you will need to use all of the APIs and tooling we provide. However, the starting point for all integrations is to create an ‘App’,
                 </mock-styled.p>
                 <svg
+                  height="100%"
                   width="100%"
                 />
               </div>
@@ -3734,7 +3765,10 @@ exports[`AppsNew should match snapshot for mobile view 1`] = `
                 >
                   For the greatest integration with our AgencyCloud Desktop CRM, we support the ability to load client-side apps using an internal web browser, inside of the CRM.
                 </mock-styled.p>
-                <svg />
+                <svg
+                  height="100%"
+                  width="100%"
+                />
               </div>
               <div
                 class=""
@@ -3839,7 +3873,10 @@ exports[`AppsNew should match snapshot for mobile view 1`] = `
                 >
                   It is possible to get up and running with a website feed from the Platform API. You will want to optimise this flow, implementing webhooks and caching however, the below video is our quick start guide.
                 </mock-styled.p>
-                <svg />
+                <svg
+                  height="100%"
+                  width="100%"
+                />
               </div>
               <div
                 class=""
@@ -3992,7 +4029,10 @@ exports[`AppsNew should match snapshot for mobile view 1`] = `
               <div
                 class="el-mb7"
               >
-                <svg />
+                <svg
+                  height="100%"
+                  width="100%"
+                />
               </div>
               <div
                 class=""

--- a/packages/developer-portal/src/components/apps/new/helper-content.tsx
+++ b/packages/developer-portal/src/components/apps/new/helper-content.tsx
@@ -90,7 +90,7 @@ export const HelperContent: FC = () => {
               of the APIs and tooling we provide. However, the starting point for all integrations is to create an
               &lsquo;App&rsquo;,
             </BodyText>
-            <VideoImage width="100%" />
+            <VideoImage width="100%" height="100%" />
           </div>
           <div className={cx(!isFlexColumn && elW6, !isFlexColumn && elMl6)}>
             <BodyText hasGreyText>
@@ -121,7 +121,7 @@ export const HelperContent: FC = () => {
               For the greatest integration with our AgencyCloud Desktop CRM, we support the ability to load client-side
               apps using an internal web browser, inside of the CRM.
             </BodyText>
-            <VideoImage />
+            <VideoImage width="100%" height="100%" />
           </div>
           <div className={cx(!isFlexColumn && elW6, !isFlexColumn && elMl6)}>
             <BodyText hasGreyText>
@@ -184,7 +184,7 @@ export const HelperContent: FC = () => {
               It is possible to get up and running with a website feed from the Platform API. You will want to optimise
               this flow, implementing webhooks and caching however, the below video is our quick start guide.
             </BodyText>
-            <VideoImage />
+            <VideoImage width="100%" height="100%" />
           </div>
           <div className={cx(!isFlexColumn && elW6, !isFlexColumn && elMl6)}>
             <BodyText hasGreyText>
@@ -258,7 +258,7 @@ export const HelperContent: FC = () => {
             className={cx(!isFlexColumn && elW6, !isFlexColumn && elMr6, isFlexColumn && elMb7)}
             onClick={openModalServerSide}
           >
-            <VideoImage />
+            <VideoImage width="100%" height="100%" />
           </div>
           <div className={cx(!isFlexColumn && elW6, !isFlexColumn && elMl6)}>
             <BodyText hasGreyText>

--- a/packages/ts-scripts/src/vite/base-vite.js
+++ b/packages/ts-scripts/src/vite/base-vite.js
@@ -92,7 +92,7 @@ module.exports = (config, appName) =>
       alias: [{ find: '@', replacement: `${path.resolve(process.cwd(), 'src')}/` }],
     },
     server: {
-      host: true,
+      host: 'localhost',
       port: 8080,
     },
   }))


### PR DESCRIPTION
# Pull request checklist

**Detail as per issue below (required):**

Resolves issue with tiny video thumbnail by forcing component to fill the available space. Issue was due to the svg element having a height of 1em when rendered. I'm not entirely sure where this was coming from, but the PR resolves the issue as shown below. The PR also alters one of the vite server properties which I had to adjust to get the application to run locally on my windows machine (using Ubuntu WSL). Without knowing the ecosystem very well I don't know if there'll be any adverse effects to changing this (I suspect not, given developers on Macs use localhost anyway), but please consider this change when reviewing.

![image](https://github.com/reapit/foundations/assets/30798627/a6497b2e-ee8f-4045-910d-2c19bb6844bf)


fixes: #10942


