### PR TITLE
fix: #11924 use correct pagination property

### DIFF
--- a/packages/data-warehouse/src/components/network/ip-table.tsx
+++ b/packages/data-warehouse/src/components/network/ip-table.tsx
@@ -86,7 +86,7 @@ export const IpTable: FC = () => {
               }
             })}
           />
-          <Pagination callback={setIpsPageNumber} currentPage={ipsPageNumber} numberPages={ips.pageCount || 0} />
+          <Pagination callback={setIpsPageNumber} currentPage={ipsPageNumber} numberPages={ips.totalPageCount || 0} />
         </>
       ) : (
         <PersistentNotification isInline isExpanded isFullWidth intent="primary">


### PR DESCRIPTION
Noticed during testing, the wrong pagination property is being used to determine the total number of pages which gives weird behaviour in the UI

