### PR TITLE
feat: rplt-420 remove change password functionality from appmarket profile

### DIFF
--- a/packages/marketplace/src/components/settings/__tests__/__snapshots__/settings-profile.test.tsx.snap
+++ b/packages/marketplace/src/components/settings/__tests__/__snapshots__/settings-profile.test.tsx.snap
@@ -93,75 +93,26 @@ exports[`SettingsProfile should match snapshot 1`] = `
       >
         Update Your Password
       </mock-styled.h2>
-      <form
-        class="el-mb11"
+      <mock-styled.p
+        classname="el-text-base el-has-grey-text"
+      >
+        Please use the Reapit Connect My Account app to manage your account
+      </mock-styled.p>
+      <mock-styled.div
+        classname="el-mb11"
       >
         <mock-styled.div
-          classname="el-form-layout-has-margin"
+          classname=""
         >
-          <mock-styled.div>
-            <mock-styled.div>
-              <mock-styled.input
-                classname=""
-                id="test-static-id"
-                name="password"
-                placeholder="Current Password"
-                type="password"
-              />
-              <mock-styled.label
-                htmlfor="test-static-id"
-              >
-                Current Password
-              </mock-styled.label>
-            </mock-styled.div>
-          </mock-styled.div>
-          <mock-styled.div>
-            <mock-styled.div>
-              <mock-styled.input
-                classname=""
-                id="test-static-id"
-                name="newPassword"
-                placeholder="New Password"
-                type="password"
-              />
-              <mock-styled.label
-                htmlfor="test-static-id"
-              >
-                New Password
-              </mock-styled.label>
-            </mock-styled.div>
-          </mock-styled.div>
-          <mock-styled.div>
-            <mock-styled.div>
-              <mock-styled.input
-                classname=""
-                id="test-static-id"
-                name="confirmPassword"
-                placeholder="Confirm New Password"
-                type="password"
-              />
-              <mock-styled.label
-                htmlfor="test-static-id"
-              >
-                Confirm New Password
-              </mock-styled.label>
-            </mock-styled.div>
-          </mock-styled.div>
-        </mock-styled.div>
-        <mock-styled.div>
-          <mock-styled.div
-            classname=""
+          <mock-styled.button
+            classname="el-intent-primary"
+            type="submit"
           >
-            <mock-styled.button
-              classname="el-intent-primary"
-              type="submit"
-            >
-              <mock-styled.div />
-              Save Changes
-            </mock-styled.button>
-          </mock-styled.div>
+            <mock-styled.div />
+            Manage Account
+          </mock-styled.button>
         </mock-styled.div>
-      </form>
+      </mock-styled.div>
       <mock-styled.h2
         classname="el-text-base el-has-bold-text"
       >
@@ -284,75 +235,26 @@ exports[`SettingsProfile should match snapshot 1`] = `
     >
       Update Your Password
     </mock-styled.h2>
-    <form
-      class="el-mb11"
+    <mock-styled.p
+      classname="el-text-base el-has-grey-text"
+    >
+      Please use the Reapit Connect My Account app to manage your account
+    </mock-styled.p>
+    <mock-styled.div
+      classname="el-mb11"
     >
       <mock-styled.div
-        classname="el-form-layout-has-margin"
+        classname=""
       >
-        <mock-styled.div>
-          <mock-styled.div>
-            <mock-styled.input
-              classname=""
-              id="test-static-id"
-              name="password"
-              placeholder="Current Password"
-              type="password"
-            />
-            <mock-styled.label
-              htmlfor="test-static-id"
-            >
-              Current Password
-            </mock-styled.label>
-          </mock-styled.div>
-        </mock-styled.div>
-        <mock-styled.div>
-          <mock-styled.div>
-            <mock-styled.input
-              classname=""
-              id="test-static-id"
-              name="newPassword"
-              placeholder="New Password"
-              type="password"
-            />
-            <mock-styled.label
-              htmlfor="test-static-id"
-            >
-              New Password
-            </mock-styled.label>
-          </mock-styled.div>
-        </mock-styled.div>
-        <mock-styled.div>
-          <mock-styled.div>
-            <mock-styled.input
-              classname=""
-              id="test-static-id"
-              name="confirmPassword"
-              placeholder="Confirm New Password"
-              type="password"
-            />
-            <mock-styled.label
-              htmlfor="test-static-id"
-            >
-              Confirm New Password
-            </mock-styled.label>
-          </mock-styled.div>
-        </mock-styled.div>
-      </mock-styled.div>
-      <mock-styled.div>
-        <mock-styled.div
-          classname=""
+        <mock-styled.button
+          classname="el-intent-primary"
+          type="submit"
         >
-          <mock-styled.button
-            classname="el-intent-primary"
-            type="submit"
-          >
-            <mock-styled.div />
-            Save Changes
-          </mock-styled.button>
-        </mock-styled.div>
+          <mock-styled.div />
+          Manage Account
+        </mock-styled.button>
       </mock-styled.div>
-    </form>
+    </mock-styled.div>
     <mock-styled.h2
       classname="el-text-base el-has-bold-text"
     >
@@ -532,75 +434,26 @@ exports[`SettingsProfile should match snapshot in mobile 1`] = `
       >
         Update Your Password
       </mock-styled.h2>
-      <form
-        class="el-mb11"
+      <mock-styled.p
+        classname="el-text-base el-has-grey-text"
+      >
+        Please use the Reapit Connect My Account app to manage your account
+      </mock-styled.p>
+      <mock-styled.div
+        classname="el-mb11"
       >
         <mock-styled.div
-          classname="el-form-layout-has-margin"
+          classname=""
         >
-          <mock-styled.div>
-            <mock-styled.div>
-              <mock-styled.input
-                classname=""
-                id="test-static-id"
-                name="password"
-                placeholder="Current Password"
-                type="password"
-              />
-              <mock-styled.label
-                htmlfor="test-static-id"
-              >
-                Current Password
-              </mock-styled.label>
-            </mock-styled.div>
-          </mock-styled.div>
-          <mock-styled.div>
-            <mock-styled.div>
-              <mock-styled.input
-                classname=""
-                id="test-static-id"
-                name="newPassword"
-                placeholder="New Password"
-                type="password"
-              />
-              <mock-styled.label
-                htmlfor="test-static-id"
-              >
-                New Password
-              </mock-styled.label>
-            </mock-styled.div>
-          </mock-styled.div>
-          <mock-styled.div>
-            <mock-styled.div>
-              <mock-styled.input
-                classname=""
-                id="test-static-id"
-                name="confirmPassword"
-                placeholder="Confirm New Password"
-                type="password"
-              />
-              <mock-styled.label
-                htmlfor="test-static-id"
-              >
-                Confirm New Password
-              </mock-styled.label>
-            </mock-styled.div>
-          </mock-styled.div>
-        </mock-styled.div>
-        <mock-styled.div>
-          <mock-styled.div
-            classname=""
+          <mock-styled.button
+            classname="el-intent-primary"
+            type="submit"
           >
-            <mock-styled.button
-              classname="el-intent-primary"
-              type="submit"
-            >
-              <mock-styled.div />
-              Save Changes
-            </mock-styled.button>
-          </mock-styled.div>
+            <mock-styled.div />
+            Manage Account
+          </mock-styled.button>
         </mock-styled.div>
-      </form>
+      </mock-styled.div>
       <mock-styled.h2
         classname="el-text-base el-has-bold-text"
       >
@@ -723,75 +576,26 @@ exports[`SettingsProfile should match snapshot in mobile 1`] = `
     >
       Update Your Password
     </mock-styled.h2>
-    <form
-      class="el-mb11"
+    <mock-styled.p
+      classname="el-text-base el-has-grey-text"
+    >
+      Please use the Reapit Connect My Account app to manage your account
+    </mock-styled.p>
+    <mock-styled.div
+      classname="el-mb11"
     >
       <mock-styled.div
-        classname="el-form-layout-has-margin"
+        classname=""
       >
-        <mock-styled.div>
-          <mock-styled.div>
-            <mock-styled.input
-              classname=""
-              id="test-static-id"
-              name="password"
-              placeholder="Current Password"
-              type="password"
-            />
-            <mock-styled.label
-              htmlfor="test-static-id"
-            >
-              Current Password
-            </mock-styled.label>
-          </mock-styled.div>
-        </mock-styled.div>
-        <mock-styled.div>
-          <mock-styled.div>
-            <mock-styled.input
-              classname=""
-              id="test-static-id"
-              name="newPassword"
-              placeholder="New Password"
-              type="password"
-            />
-            <mock-styled.label
-              htmlfor="test-static-id"
-            >
-              New Password
-            </mock-styled.label>
-          </mock-styled.div>
-        </mock-styled.div>
-        <mock-styled.div>
-          <mock-styled.div>
-            <mock-styled.input
-              classname=""
-              id="test-static-id"
-              name="confirmPassword"
-              placeholder="Confirm New Password"
-              type="password"
-            />
-            <mock-styled.label
-              htmlfor="test-static-id"
-            >
-              Confirm New Password
-            </mock-styled.label>
-          </mock-styled.div>
-        </mock-styled.div>
-      </mock-styled.div>
-      <mock-styled.div>
-        <mock-styled.div
-          classname=""
+        <mock-styled.button
+          classname="el-intent-primary"
+          type="submit"
         >
-          <mock-styled.button
-            classname="el-intent-primary"
-            type="submit"
-          >
-            <mock-styled.div />
-            Save Changes
-          </mock-styled.button>
-        </mock-styled.div>
+          <mock-styled.div />
+          Manage Account
+        </mock-styled.button>
       </mock-styled.div>
-    </form>
+    </mock-styled.div>
     <mock-styled.h2
       classname="el-text-base el-has-bold-text"
     >

--- a/packages/marketplace/src/components/settings/__tests__/settings-profile.test.tsx
+++ b/packages/marketplace/src/components/settings/__tests__/settings-profile.test.tsx
@@ -1,19 +1,12 @@
 import React from 'react'
 import { render, setViewport } from '../../../tests/react-testing'
-import { SettingsProfile, handleChangePassword, handleUserUpdate } from '../settings-profile'
-import { changePasswordService } from '../../../services/cognito-identity'
-import { UseSnack } from '@reapit/elements'
-import { TrackingEvent } from '../../../core/analytics-events'
-import { trackEvent } from '../../../core/analytics'
+import { SettingsProfile, handleUserUpdate } from '../settings-profile'
 import { mockUserModel } from '../../../tests/__stubs__/user'
 import { SendFunction } from '@reapit/use-reapit-data'
 import { UpdateUserModel } from '@reapit/foundations-ts-definitions'
 
 jest.mock('../../../core/use-apps-browse-state')
 jest.mock('../../../core/analytics')
-jest.mock('../../../services/cognito-identity', () => ({
-  changePasswordService: jest.fn(),
-}))
 jest.mock('@reapit/connect-session', () => ({
   ReapitConnectBrowserSession: jest.fn(),
   useReapitConnect: jest.fn(() => ({
@@ -30,8 +23,6 @@ jest.mock('@reapit/connect-session', () => ({
   })),
 }))
 
-const mockChangePasswordService = changePasswordService as jest.Mock
-
 describe('SettingsProfile', () => {
   it('should match snapshot', () => {
     expect(render(<SettingsProfile />)).toMatchSnapshot()
@@ -40,63 +31,6 @@ describe('SettingsProfile', () => {
   it('should match snapshot in mobile', () => {
     setViewport('mobile')
     expect(render(<SettingsProfile />)).toMatchSnapshot()
-  })
-})
-
-describe('handleChangePassword', () => {
-  it('should successfully change the password', async () => {
-    mockChangePasswordService.mockReturnValue(true)
-    const email = 'MOCK_EMAIL'
-    const snack = {
-      success: jest.fn(),
-      error: jest.fn(),
-    } as unknown as UseSnack
-    const formValues = {
-      password: 'MOCK_PASSWORD',
-      newPassword: 'MOCK_NEW_PASSWORD',
-      confirmPassword: 'MOCK_NEW_PASSWORD',
-    }
-
-    const curried = handleChangePassword(email, snack)
-
-    await curried(formValues)
-
-    expect(mockChangePasswordService).toHaveBeenCalledWith({
-      password: formValues.password,
-      newPassword: formValues.newPassword,
-      userName: email,
-    })
-
-    expect(trackEvent).toHaveBeenCalledWith(TrackingEvent.ChangePassword, true)
-    expect(snack.error).not.toHaveBeenCalled()
-    expect(snack.success).toHaveBeenCalledTimes(1)
-  })
-
-  it('should throw an error if the change password service fails', async () => {
-    mockChangePasswordService.mockReturnValue(false)
-    const email = 'MOCK_EMAIL'
-    const snack = {
-      success: jest.fn(),
-      error: jest.fn(),
-    } as unknown as UseSnack
-    const formValues = {
-      password: 'MOCK_PASSWORD',
-      newPassword: 'MOCK_NEW_PASSWORD',
-      confirmPassword: 'MOCK_NEW_PASSWORD',
-    }
-
-    const curried = handleChangePassword(email, snack)
-
-    await curried(formValues)
-
-    expect(mockChangePasswordService).toHaveBeenCalledWith({
-      password: formValues.password,
-      newPassword: formValues.newPassword,
-      userName: email,
-    })
-
-    expect(snack.error).toHaveBeenCalledTimes(1)
-    expect(snack.success).not.toHaveBeenCalled()
   })
 })
 

--- a/packages/marketplace/src/components/settings/__tests__/settings-profile.test.tsx
+++ b/packages/marketplace/src/components/settings/__tests__/settings-profile.test.tsx
@@ -24,6 +24,10 @@ jest.mock('@reapit/connect-session', () => ({
 }))
 
 describe('SettingsProfile', () => {
+  beforeEach(() => {
+    process.env.appEnv = 'local'
+  })
+
   it('should match snapshot', () => {
     expect(render(<SettingsProfile />)).toMatchSnapshot()
   })

--- a/packages/marketplace/src/components/settings/settings-profile.tsx
+++ b/packages/marketplace/src/components/settings/settings-profile.tsx
@@ -16,7 +16,7 @@ import {
 import { LoginIdentity, useReapitConnect } from '@reapit/connect-session'
 import { reapitConnectBrowserSession } from '../../core/connect-session'
 import { RolesChip } from './__styles__'
-import { trackEventHandler, trackEvent } from '../../core/analytics'
+import { trackEventHandler } from '../../core/analytics'
 import { TrackingEvent } from '../../core/analytics-events'
 import { UpdateUserModel, UserModel } from '@reapit/foundations-ts-definitions'
 import { updateActions, UpdateActionNames } from '@reapit/use-reapit-data'

--- a/packages/marketplace/src/constants/urls.ts
+++ b/packages/marketplace/src/constants/urls.ts
@@ -1,0 +1,11 @@
+export const URLS = {
+  production: {
+    reapitConnectMyAccount: 'https://connect.reapit.cloud/my-account',
+  },
+  development: {
+    reapitConnectMyAccount: 'https://connect.dev.paas.reapit.cloud/my-account',
+  },
+  local: {
+    reapitConnectMyAccount: 'https://connect.dev.paas.reapit.cloud/my-account',
+  },
+}

--- a/packages/marketplace/src/services/cognito-identity.ts
+++ b/packages/marketplace/src/services/cognito-identity.ts
@@ -27,36 +27,6 @@ export interface ConfirmRegistrationParams {
   connectClientId: string
 }
 
-export const changePasswordService = async ({
-  password,
-  userName,
-  newPassword,
-}: ChangePasswordParams): Promise<boolean> => {
-  return new Promise((resolve, reject) => {
-    const authenticationData = {
-      Username: userName,
-      Password: password,
-    }
-    const authenticationDetails = new AuthenticationDetails(authenticationData)
-    const cognitoUser = getNewUser(userName, process.env.connectClientId)
-    cognitoUser.authenticateUser(authenticationDetails, {
-      onSuccess: () => {
-        cognitoUser.changePassword(password, newPassword, (err) => {
-          if (err) {
-            logger(new Error(err.message))
-            reject(err)
-          }
-          resolve(true)
-        })
-      },
-      onFailure: (err) => {
-        logger(new Error(err.message))
-        resolve(false)
-      },
-    })
-  })
-}
-
 export const confirmRegistrationService = async ({
   verificationCode,
   userName,

--- a/packages/marketplace/src/services/cognito-identity.ts
+++ b/packages/marketplace/src/services/cognito-identity.ts
@@ -1,5 +1,5 @@
 /* istanbul ignore file */
-import { CognitoUserPool, CognitoUser, AuthenticationDetails } from 'amazon-cognito-identity-js'
+import { CognitoUserPool, CognitoUser } from 'amazon-cognito-identity-js'
 import { logger } from '@reapit/utils-react'
 
 export const getNewUser = (userName: string, connectClientId: string, userPoolId?: string) => {


### PR DESCRIPTION
# Pull request checklist
- Updates AppMarket profile page to no longer permit password updates directly from the page, instead signposting user to my-account page
- This shouldn't be merged until the Reapit Connect updates are out the door

![image](https://github.com/user-attachments/assets/5ec0d5a9-9ac2-438c-b407-50d5c3c6be1f)




