### PR TITLE
feat: rplt-397 replace change password with signpost to my-account

### DIFF
--- a/packages/developer-portal/src/components/settings/password/__tests__/__snapshots__/change-password-form.test.tsx.snap
+++ b/packages/developer-portal/src/components/settings/password/__tests__/__snapshots__/change-password-form.test.tsx.snap
@@ -6,131 +6,14 @@ exports[`ChangePasswordForm should match snapshot 1`] = `
   "baseElement": <body>
     <div>
       <mock-styled.div />
-      <form>
-        <mock-styled.div
-          classname="el-form-layout-has-margin"
-        >
-          <mock-styled.div>
-            <mock-styled.div>
-              <mock-styled.input
-                classname=""
-                id="test-static-id"
-                name="password"
-                placeholder="Current Password"
-                type="password"
-              />
-              <mock-styled.label
-                htmlfor="test-static-id"
-              >
-                Current Password
-              </mock-styled.label>
-            </mock-styled.div>
-          </mock-styled.div>
-          <mock-styled.div>
-            <mock-styled.div>
-              <mock-styled.input
-                classname=""
-                id="test-static-id"
-                name="newPassword"
-                placeholder="New Password"
-                type="password"
-              />
-              <mock-styled.label
-                htmlfor="test-static-id"
-              >
-                New Password
-              </mock-styled.label>
-            </mock-styled.div>
-          </mock-styled.div>
-          <mock-styled.div>
-            <mock-styled.div>
-              <mock-styled.input
-                classname=""
-                id="test-static-id"
-                name="confirmPassword"
-                placeholder="Confirm New Password"
-                type="password"
-              />
-              <mock-styled.label
-                htmlfor="test-static-id"
-              >
-                Confirm New Password
-              </mock-styled.label>
-            </mock-styled.div>
-          </mock-styled.div>
-        </mock-styled.div>
-        <mock-styled.div>
-          <mock-styled.div
-            classname=""
-          >
-            <mock-styled.button
-              classname="el-intent-primary"
-              type="submit"
-            >
-              <mock-styled.div />
-              Save Changes
-            </mock-styled.button>
-          </mock-styled.div>
-        </mock-styled.div>
-      </form>
-    </div>
-  </body>,
-  "container": <div>
-    <mock-styled.div />
-    <form>
-      <mock-styled.div
-        classname="el-form-layout-has-margin"
+      <mock-styled.p
+        classname="el-text-base el-has-grey-text"
       >
-        <mock-styled.div>
-          <mock-styled.div>
-            <mock-styled.input
-              classname=""
-              id="test-static-id"
-              name="password"
-              placeholder="Current Password"
-              type="password"
-            />
-            <mock-styled.label
-              htmlfor="test-static-id"
-            >
-              Current Password
-            </mock-styled.label>
-          </mock-styled.div>
-        </mock-styled.div>
-        <mock-styled.div>
-          <mock-styled.div>
-            <mock-styled.input
-              classname=""
-              id="test-static-id"
-              name="newPassword"
-              placeholder="New Password"
-              type="password"
-            />
-            <mock-styled.label
-              htmlfor="test-static-id"
-            >
-              New Password
-            </mock-styled.label>
-          </mock-styled.div>
-        </mock-styled.div>
-        <mock-styled.div>
-          <mock-styled.div>
-            <mock-styled.input
-              classname=""
-              id="test-static-id"
-              name="confirmPassword"
-              placeholder="Confirm New Password"
-              type="password"
-            />
-            <mock-styled.label
-              htmlfor="test-static-id"
-            >
-              Confirm New Password
-            </mock-styled.label>
-          </mock-styled.div>
-        </mock-styled.div>
-      </mock-styled.div>
-      <mock-styled.div>
+        Please use the Reapit Connect My Account app to manage your account
+      </mock-styled.p>
+      <mock-styled.div
+        classname="el-mb11"
+      >
         <mock-styled.div
           classname=""
         >
@@ -139,11 +22,34 @@ exports[`ChangePasswordForm should match snapshot 1`] = `
             type="submit"
           >
             <mock-styled.div />
-            Save Changes
+            Manage Account
           </mock-styled.button>
         </mock-styled.div>
       </mock-styled.div>
-    </form>
+    </div>
+  </body>,
+  "container": <div>
+    <mock-styled.div />
+    <mock-styled.p
+      classname="el-text-base el-has-grey-text"
+    >
+      Please use the Reapit Connect My Account app to manage your account
+    </mock-styled.p>
+    <mock-styled.div
+      classname="el-mb11"
+    >
+      <mock-styled.div
+        classname=""
+      >
+        <mock-styled.button
+          classname="el-intent-primary"
+          type="submit"
+        >
+          <mock-styled.div />
+          Manage Account
+        </mock-styled.button>
+      </mock-styled.div>
+    </mock-styled.div>
   </div>,
   "debug": [Function],
   "findAllByAltText": [Function],

--- a/packages/developer-portal/src/components/settings/password/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/developer-portal/src/components/settings/password/__tests__/__snapshots__/index.test.tsx.snap
@@ -11,73 +11,26 @@ exports[`SettingsPasswordPage should match snapshot 1`] = `
       >
         Password
       </mock-styled.h1>
-      <form>
+      <mock-styled.p
+        classname="el-text-base el-has-grey-text"
+      >
+        Please use the Reapit Connect My Account app to manage your account
+      </mock-styled.p>
+      <mock-styled.div
+        classname="el-mb11"
+      >
         <mock-styled.div
-          classname="el-form-layout-has-margin"
+          classname=""
         >
-          <mock-styled.div>
-            <mock-styled.div>
-              <mock-styled.input
-                classname=""
-                id="test-static-id"
-                name="password"
-                placeholder="Current Password"
-                type="password"
-              />
-              <mock-styled.label
-                htmlfor="test-static-id"
-              >
-                Current Password
-              </mock-styled.label>
-            </mock-styled.div>
-          </mock-styled.div>
-          <mock-styled.div>
-            <mock-styled.div>
-              <mock-styled.input
-                classname=""
-                id="test-static-id"
-                name="newPassword"
-                placeholder="New Password"
-                type="password"
-              />
-              <mock-styled.label
-                htmlfor="test-static-id"
-              >
-                New Password
-              </mock-styled.label>
-            </mock-styled.div>
-          </mock-styled.div>
-          <mock-styled.div>
-            <mock-styled.div>
-              <mock-styled.input
-                classname=""
-                id="test-static-id"
-                name="confirmPassword"
-                placeholder="Confirm New Password"
-                type="password"
-              />
-              <mock-styled.label
-                htmlfor="test-static-id"
-              >
-                Confirm New Password
-              </mock-styled.label>
-            </mock-styled.div>
-          </mock-styled.div>
-        </mock-styled.div>
-        <mock-styled.div>
-          <mock-styled.div
-            classname=""
+          <mock-styled.button
+            classname="el-intent-primary"
+            type="submit"
           >
-            <mock-styled.button
-              classname="el-intent-primary"
-              type="submit"
-            >
-              <mock-styled.div />
-              Save Changes
-            </mock-styled.button>
-          </mock-styled.div>
+            <mock-styled.div />
+            Manage Account
+          </mock-styled.button>
         </mock-styled.div>
-      </form>
+      </mock-styled.div>
       <mock-styled.div
         aria-hidden="true"
         classname=""
@@ -119,73 +72,26 @@ exports[`SettingsPasswordPage should match snapshot 1`] = `
     >
       Password
     </mock-styled.h1>
-    <form>
+    <mock-styled.p
+      classname="el-text-base el-has-grey-text"
+    >
+      Please use the Reapit Connect My Account app to manage your account
+    </mock-styled.p>
+    <mock-styled.div
+      classname="el-mb11"
+    >
       <mock-styled.div
-        classname="el-form-layout-has-margin"
+        classname=""
       >
-        <mock-styled.div>
-          <mock-styled.div>
-            <mock-styled.input
-              classname=""
-              id="test-static-id"
-              name="password"
-              placeholder="Current Password"
-              type="password"
-            />
-            <mock-styled.label
-              htmlfor="test-static-id"
-            >
-              Current Password
-            </mock-styled.label>
-          </mock-styled.div>
-        </mock-styled.div>
-        <mock-styled.div>
-          <mock-styled.div>
-            <mock-styled.input
-              classname=""
-              id="test-static-id"
-              name="newPassword"
-              placeholder="New Password"
-              type="password"
-            />
-            <mock-styled.label
-              htmlfor="test-static-id"
-            >
-              New Password
-            </mock-styled.label>
-          </mock-styled.div>
-        </mock-styled.div>
-        <mock-styled.div>
-          <mock-styled.div>
-            <mock-styled.input
-              classname=""
-              id="test-static-id"
-              name="confirmPassword"
-              placeholder="Confirm New Password"
-              type="password"
-            />
-            <mock-styled.label
-              htmlfor="test-static-id"
-            >
-              Confirm New Password
-            </mock-styled.label>
-          </mock-styled.div>
-        </mock-styled.div>
-      </mock-styled.div>
-      <mock-styled.div>
-        <mock-styled.div
-          classname=""
+        <mock-styled.button
+          classname="el-intent-primary"
+          type="submit"
         >
-          <mock-styled.button
-            classname="el-intent-primary"
-            type="submit"
-          >
-            <mock-styled.div />
-            Save Changes
-          </mock-styled.button>
-        </mock-styled.div>
+          <mock-styled.div />
+          Manage Account
+        </mock-styled.button>
       </mock-styled.div>
-    </form>
+    </mock-styled.div>
     <mock-styled.div
       aria-hidden="true"
       classname=""
@@ -289,73 +195,26 @@ exports[`SettingsPasswordPage should match snapshot for mobile view 1`] = `
       >
         Password
       </mock-styled.h1>
-      <form>
+      <mock-styled.p
+        classname="el-text-base el-has-grey-text"
+      >
+        Please use the Reapit Connect My Account app to manage your account
+      </mock-styled.p>
+      <mock-styled.div
+        classname="el-mb11"
+      >
         <mock-styled.div
-          classname="el-form-layout-has-margin"
+          classname=""
         >
-          <mock-styled.div>
-            <mock-styled.div>
-              <mock-styled.input
-                classname=""
-                id="test-static-id"
-                name="password"
-                placeholder="Current Password"
-                type="password"
-              />
-              <mock-styled.label
-                htmlfor="test-static-id"
-              >
-                Current Password
-              </mock-styled.label>
-            </mock-styled.div>
-          </mock-styled.div>
-          <mock-styled.div>
-            <mock-styled.div>
-              <mock-styled.input
-                classname=""
-                id="test-static-id"
-                name="newPassword"
-                placeholder="New Password"
-                type="password"
-              />
-              <mock-styled.label
-                htmlfor="test-static-id"
-              >
-                New Password
-              </mock-styled.label>
-            </mock-styled.div>
-          </mock-styled.div>
-          <mock-styled.div>
-            <mock-styled.div>
-              <mock-styled.input
-                classname=""
-                id="test-static-id"
-                name="confirmPassword"
-                placeholder="Confirm New Password"
-                type="password"
-              />
-              <mock-styled.label
-                htmlfor="test-static-id"
-              >
-                Confirm New Password
-              </mock-styled.label>
-            </mock-styled.div>
-          </mock-styled.div>
-        </mock-styled.div>
-        <mock-styled.div>
-          <mock-styled.div
-            classname=""
+          <mock-styled.button
+            classname="el-intent-primary"
+            type="submit"
           >
-            <mock-styled.button
-              classname="el-intent-primary"
-              type="submit"
-            >
-              <mock-styled.div />
-              Save Changes
-            </mock-styled.button>
-          </mock-styled.div>
+            <mock-styled.div />
+            Manage Account
+          </mock-styled.button>
         </mock-styled.div>
-      </form>
+      </mock-styled.div>
       <mock-styled.div
         aria-hidden="true"
         classname=""
@@ -397,73 +256,26 @@ exports[`SettingsPasswordPage should match snapshot for mobile view 1`] = `
     >
       Password
     </mock-styled.h1>
-    <form>
+    <mock-styled.p
+      classname="el-text-base el-has-grey-text"
+    >
+      Please use the Reapit Connect My Account app to manage your account
+    </mock-styled.p>
+    <mock-styled.div
+      classname="el-mb11"
+    >
       <mock-styled.div
-        classname="el-form-layout-has-margin"
+        classname=""
       >
-        <mock-styled.div>
-          <mock-styled.div>
-            <mock-styled.input
-              classname=""
-              id="test-static-id"
-              name="password"
-              placeholder="Current Password"
-              type="password"
-            />
-            <mock-styled.label
-              htmlfor="test-static-id"
-            >
-              Current Password
-            </mock-styled.label>
-          </mock-styled.div>
-        </mock-styled.div>
-        <mock-styled.div>
-          <mock-styled.div>
-            <mock-styled.input
-              classname=""
-              id="test-static-id"
-              name="newPassword"
-              placeholder="New Password"
-              type="password"
-            />
-            <mock-styled.label
-              htmlfor="test-static-id"
-            >
-              New Password
-            </mock-styled.label>
-          </mock-styled.div>
-        </mock-styled.div>
-        <mock-styled.div>
-          <mock-styled.div>
-            <mock-styled.input
-              classname=""
-              id="test-static-id"
-              name="confirmPassword"
-              placeholder="Confirm New Password"
-              type="password"
-            />
-            <mock-styled.label
-              htmlfor="test-static-id"
-            >
-              Confirm New Password
-            </mock-styled.label>
-          </mock-styled.div>
-        </mock-styled.div>
-      </mock-styled.div>
-      <mock-styled.div>
-        <mock-styled.div
-          classname=""
+        <mock-styled.button
+          classname="el-intent-primary"
+          type="submit"
         >
-          <mock-styled.button
-            classname="el-intent-primary"
-            type="submit"
-          >
-            <mock-styled.div />
-            Save Changes
-          </mock-styled.button>
-        </mock-styled.div>
+          <mock-styled.div />
+          Manage Account
+        </mock-styled.button>
       </mock-styled.div>
-    </form>
+    </mock-styled.div>
     <mock-styled.div
       aria-hidden="true"
       classname=""

--- a/packages/developer-portal/src/components/settings/password/__tests__/change-password-form.test.tsx
+++ b/packages/developer-portal/src/components/settings/password/__tests__/change-password-form.test.tsx
@@ -1,73 +1,17 @@
 import React from 'react'
-import { ChangePasswordForm, handleChangePassword } from '../change-password-form'
+import { ChangePasswordForm } from '../change-password-form'
 import { render } from '../../../../tests/react-testing'
-import { changePasswordService } from '../../../../services/cognito-identity'
-import { UseSnack } from '@reapit/elements'
 
 jest.mock('../../../../services/cognito-identity', () => ({
   changePasswordService: jest.fn(),
 }))
 
-const mockChangePasswordService = changePasswordService as jest.Mock
-
 describe('ChangePasswordForm', () => {
+  beforeEach(() => {
+    process.env.appEnv = 'local'
+  })
+
   it('should match snapshot', () => {
     expect(render(<ChangePasswordForm />)).toMatchSnapshot()
-  })
-})
-
-describe('handleChangePassword', () => {
-  it('should successfully change the password', async () => {
-    mockChangePasswordService.mockReturnValue(true)
-    const email = 'MOCK_EMAIL'
-    const snack = {
-      success: jest.fn(),
-      error: jest.fn(),
-    } as unknown as UseSnack
-    const formValues = {
-      password: 'MOCK_PASSWORD',
-      newPassword: 'MOCK_NEW_PASSWORD',
-      confirmPassword: 'MOCK_NEW_PASSWORD',
-    }
-
-    const curried = handleChangePassword(email, snack)
-
-    await curried(formValues)
-
-    expect(mockChangePasswordService).toHaveBeenCalledWith({
-      password: formValues.password,
-      newPassword: formValues.newPassword,
-      userName: email,
-    })
-
-    expect(snack.error).not.toHaveBeenCalled()
-    expect(snack.success).toHaveBeenCalledTimes(1)
-  })
-
-  it('should throw an error if the change password service fails', async () => {
-    mockChangePasswordService.mockReturnValue(false)
-    const email = 'MOCK_EMAIL'
-    const snack = {
-      success: jest.fn(),
-      error: jest.fn(),
-    } as unknown as UseSnack
-    const formValues = {
-      password: 'MOCK_PASSWORD',
-      newPassword: 'MOCK_NEW_PASSWORD',
-      confirmPassword: 'MOCK_NEW_PASSWORD',
-    }
-
-    const curried = handleChangePassword(email, snack)
-
-    await curried(formValues)
-
-    expect(mockChangePasswordService).toHaveBeenCalledWith({
-      password: formValues.password,
-      newPassword: formValues.newPassword,
-      userName: email,
-    })
-
-    expect(snack.error).toHaveBeenCalledTimes(1)
-    expect(snack.success).not.toHaveBeenCalled()
   })
 })

--- a/packages/developer-portal/src/components/settings/password/__tests__/index.test.tsx
+++ b/packages/developer-portal/src/components/settings/password/__tests__/index.test.tsx
@@ -3,6 +3,10 @@ import { SettingsPasswordPage } from '..'
 import { render, setViewport } from '../../../../tests/react-testing'
 
 describe('SettingsPasswordPage', () => {
+  beforeEach(() => {
+    process.env.appEnv = 'local'
+  })
+
   it('should match snapshot', () => {
     expect(render(<SettingsPasswordPage />)).toMatchSnapshot()
   })

--- a/packages/developer-portal/src/components/settings/password/change-password-form.tsx
+++ b/packages/developer-portal/src/components/settings/password/change-password-form.tsx
@@ -1,93 +1,19 @@
 import React, { FC } from 'react'
-import { Button, ButtonGroup, FormLayout, InputGroup, InputWrap, UseSnack, useSnack } from '@reapit/elements'
-import { useReapitConnect } from '@reapit/connect-session'
-import { reapitConnectBrowserSession } from '../../../core/connect-session'
-import { useForm } from 'react-hook-form'
-import { yupResolver } from '@hookform/resolvers/yup'
-import { validationSchemaChangePassword } from './validation-schema'
-import { changePasswordService } from '../../../services/cognito-identity'
-
-export type ChangePasswordFormValues = {
-  password: string
-  newPassword: string
-  confirmPassword: string
-}
-
-export const handleChangePassword =
-  (email: string, { success, error }: UseSnack) =>
-  async ({ newPassword, password }: ChangePasswordFormValues) => {
-    const passwordChanged = await changePasswordService({
-      password,
-      newPassword,
-      userName: email,
-    })
-
-    if (passwordChanged) {
-      success('Successfully updated your password')
-    } else {
-      error('Failed to update your password. This error has been logged, please try again')
-    }
-  }
+import { BodyText, Button, ButtonGroup, elMb11 } from '@reapit/elements'
+import { openNewPage } from '../../../utils/navigation'
+import { URLS } from '../../../constants/urls'
 
 export const ChangePasswordForm: FC = () => {
-  const { connectSession } = useReapitConnect(reapitConnectBrowserSession)
-  const snacks = useSnack()
-  const email = connectSession?.loginIdentity.email ?? ''
-  const {
-    register,
-    handleSubmit,
-    formState: { errors },
-  } = useForm<ChangePasswordFormValues>({
-    resolver: yupResolver(validationSchemaChangePassword),
-    defaultValues: {
-      password: '',
-      newPassword: '',
-      confirmPassword: '',
-    },
-  })
+  const appEnv = process.env.appEnv
 
   return (
-    <form onSubmit={handleSubmit(handleChangePassword(email, snacks))}>
-      <FormLayout hasMargin>
-        <InputWrap>
-          <InputGroup
-            {...register('password')}
-            type="password"
-            label="Current Password"
-            placeholder="Current Password"
-            errorMessage={errors?.password?.message}
-            icon={errors?.password?.message ? 'asterisk' : null}
-            intent="danger"
-          />
-        </InputWrap>
-        <InputWrap>
-          <InputGroup
-            {...register('newPassword')}
-            type="password"
-            label="New Password"
-            placeholder="New Password"
-            errorMessage={errors?.newPassword?.message}
-            icon={errors?.newPassword?.message ? 'asterisk' : null}
-            intent="danger"
-          />
-        </InputWrap>
-        <InputWrap>
-          <InputGroup
-            {...register('confirmPassword')}
-            type="password"
-            label="Confirm New Password"
-            placeholder="Confirm New Password"
-            errorMessage={errors?.confirmPassword?.message}
-            icon={errors?.confirmPassword?.message ? 'asterisk' : null}
-            intent="danger"
-          />
-        </InputWrap>
-      </FormLayout>
-      <ButtonGroup>
-        <Button intent="primary" type="submit">
-          Save Changes
+    <>
+      <BodyText hasGreyText>Please use the Reapit Connect My Account app to manage your account</BodyText>
+      <ButtonGroup className={elMb11}>
+        <Button intent="primary" type="submit" onClick={openNewPage(`${URLS[appEnv].reapitConnectMyAccount}`)}>
+          Manage Account
         </Button>
       </ButtonGroup>
-    </form>
+    </>
   )
 }

--- a/packages/developer-portal/src/constants/urls.ts
+++ b/packages/developer-portal/src/constants/urls.ts
@@ -1,0 +1,11 @@
+export const URLS = {
+  production: {
+    reapitConnectMyAccount: 'https://connect.reapit.cloud/my-account',
+  },
+  development: {
+    reapitConnectMyAccount: 'https://connect.dev.paas.reapit.cloud/my-account',
+  },
+  local: {
+    reapitConnectMyAccount: 'https://connect.dev.paas.reapit.cloud/my-account',
+  },
+}

--- a/packages/developer-portal/src/services/cognito-identity.ts
+++ b/packages/developer-portal/src/services/cognito-identity.ts
@@ -1,4 +1,4 @@
-import { CognitoUserPool, CognitoUser, AuthenticationDetails } from 'amazon-cognito-identity-js'
+import { CognitoUserPool, CognitoUser } from 'amazon-cognito-identity-js'
 import { logger } from '@reapit/utils-react'
 
 export const getNewUser = (userName: string, connectClientId: string, userPoolId?: string) => {
@@ -14,46 +14,10 @@ export const getNewUser = (userName: string, connectClientId: string, userPoolId
   return new CognitoUser(userData)
 }
 
-export interface ChangePasswordParams {
-  newPassword: string
-  userName: string
-  password: string
-}
-
 export interface ConfirmRegistrationParams {
   userName: string
   verificationCode: string
   connectClientId: string
-}
-
-export const changePasswordService = async ({
-  password,
-  userName,
-  newPassword,
-}: ChangePasswordParams): Promise<boolean> => {
-  return new Promise((resolve, reject) => {
-    const authenticationData = {
-      Username: userName,
-      Password: password,
-    }
-    const authenticationDetails = new AuthenticationDetails(authenticationData)
-    const cognitoUser = getNewUser(userName, process.env.connectClientId)
-    cognitoUser.authenticateUser(authenticationDetails, {
-      onSuccess: () => {
-        cognitoUser.changePassword(password, newPassword, (err) => {
-          if (err) {
-            logger(new Error(err.message))
-            reject(err)
-          }
-          resolve(true)
-        })
-      },
-      onFailure: (err) => {
-        logger(new Error(err.message))
-        resolve(false)
-      },
-    })
-  })
 }
 
 export const confirmRegistrationService = async ({


### PR DESCRIPTION
# Pull request checklist
- Updates DeveloperPortal password page to no longer permit password updates directly from the page, instead signposting user to my-account page
- This shouldn't be merged until the Reapit Connect updates are out the door

![image](https://github.com/user-attachments/assets/19105360-908c-484d-9c1b-eab4ac646a4c)

