### PR TITLE
feat: rplt-135 capture user email address when provisioning data warehouse user accounts

### DIFF
--- a/packages/data-warehouse/src/components/accounts/__tests__/__snapshots__/account-provision-modal.test.tsx.snap
+++ b/packages/data-warehouse/src/components/accounts/__tests__/__snapshots__/account-provision-modal.test.tsx.snap
@@ -16,7 +16,9 @@ exports[`AccountProvisionModal should match a snapshot 1`] = `
           classname="el-mb11"
         >
           <mock-styled.div>
-            <mock-styled.div>
+            <mock-styled.div
+              classname="el-w6"
+            >
               <mock-styled.input
                 classname=""
                 id="test-static-id"
@@ -32,7 +34,9 @@ exports[`AccountProvisionModal should match a snapshot 1`] = `
             </mock-styled.div>
           </mock-styled.div>
           <mock-styled.div>
-            <mock-styled.div>
+            <mock-styled.div
+              classname="el-w6"
+            >
               <mock-styled.input
                 classname=""
                 id="test-static-id"
@@ -48,7 +52,9 @@ exports[`AccountProvisionModal should match a snapshot 1`] = `
             </mock-styled.div>
           </mock-styled.div>
           <mock-styled.div>
-            <mock-styled.div>
+            <mock-styled.div
+              classname="el-w6"
+            >
               <mock-styled.input
                 classname=""
                 id="test-static-id"
@@ -62,6 +68,23 @@ exports[`AccountProvisionModal should match a snapshot 1`] = `
                 Confirm Password
               </mock-styled.label>
             </mock-styled.div>
+          </mock-styled.div>
+        </mock-styled.div>
+        <mock-styled.p
+          classname="el-text-base el-has-grey-text"
+        >
+          Please provide an email address so we know who to contact about this account
+        </mock-styled.p>
+        <mock-styled.div
+          classname="el-mb11"
+        >
+          <mock-styled.div>
+            <mock-styled.input
+              classname="el-w6"
+              name="email"
+              placeholder="Your email address"
+              type="text"
+            />
           </mock-styled.div>
         </mock-styled.div>
         <mock-styled.div>
@@ -99,7 +122,9 @@ exports[`AccountProvisionModal should match a snapshot 1`] = `
         classname="el-mb11"
       >
         <mock-styled.div>
-          <mock-styled.div>
+          <mock-styled.div
+            classname="el-w6"
+          >
             <mock-styled.input
               classname=""
               id="test-static-id"
@@ -115,7 +140,9 @@ exports[`AccountProvisionModal should match a snapshot 1`] = `
           </mock-styled.div>
         </mock-styled.div>
         <mock-styled.div>
-          <mock-styled.div>
+          <mock-styled.div
+            classname="el-w6"
+          >
             <mock-styled.input
               classname=""
               id="test-static-id"
@@ -131,7 +158,9 @@ exports[`AccountProvisionModal should match a snapshot 1`] = `
           </mock-styled.div>
         </mock-styled.div>
         <mock-styled.div>
-          <mock-styled.div>
+          <mock-styled.div
+            classname="el-w6"
+          >
             <mock-styled.input
               classname=""
               id="test-static-id"
@@ -145,6 +174,23 @@ exports[`AccountProvisionModal should match a snapshot 1`] = `
               Confirm Password
             </mock-styled.label>
           </mock-styled.div>
+        </mock-styled.div>
+      </mock-styled.div>
+      <mock-styled.p
+        classname="el-text-base el-has-grey-text"
+      >
+        Please provide an email address so we know who to contact about this account
+      </mock-styled.p>
+      <mock-styled.div
+        classname="el-mb11"
+      >
+        <mock-styled.div>
+          <mock-styled.input
+            classname="el-w6"
+            name="email"
+            placeholder="Your email address"
+            type="text"
+          />
         </mock-styled.div>
       </mock-styled.div>
       <mock-styled.div>

--- a/packages/data-warehouse/src/components/accounts/account-provision-modal.tsx
+++ b/packages/data-warehouse/src/components/accounts/account-provision-modal.tsx
@@ -3,7 +3,18 @@ import { passwordRegex } from '@reapit/utils-common'
 import { reapitConnectBrowserSession } from '../../core/connect-session'
 import { useReapitConnect } from '@reapit/connect-session'
 import { AccountCreateModel, AccountModel } from '../../types/accounts'
-import { BodyText, Button, ButtonGroup, elMb11, FormLayout, InputError, InputGroup, InputWrap } from '@reapit/elements'
+import {
+  BodyText,
+  Button,
+  ButtonGroup,
+  elMb11,
+  elW6,
+  FormLayout,
+  Input,
+  InputError,
+  InputGroup,
+  InputWrapFull,
+} from '@reapit/elements'
 import { useGlobalState } from '../../core/use-global-state'
 import { object, ref, string } from 'yup'
 import { useForm } from 'react-hook-form'
@@ -34,6 +45,7 @@ const validationSchema = object({
   passwordConfirm: string()
     .oneOf([ref('password')], 'Passwords must match')
     .required('Required'),
+  email: string().required('Required'),
 })
 
 export const handlePolling = (accountId: string): Promise<{ provisioned: boolean; interval: number }> => {
@@ -154,23 +166,46 @@ export const AccountProvisionModal: FC<AccountProvisionModalProps> = ({
     >
       <BodyText hasGreyText>The information below will be used to access your data warehouse account</BodyText>
       <FormLayout className={elMb11}>
-        <InputWrap>
-          <InputGroup {...register('username')} type="text" placeholder="Your username here" label="Username" />
+        <InputWrapFull>
+          <InputGroup
+            {...register('username')}
+            type="text"
+            placeholder="Your username here"
+            label="Username"
+            className={elW6}
+          />
           {errors.username?.message && <InputError message={errors.username.message} />}
-        </InputWrap>
-        <InputWrap>
-          <InputGroup {...register('password')} type="password" placeholder="*********" label="Password" />
+        </InputWrapFull>
+
+        <InputWrapFull>
+          <InputGroup
+            {...register('password')}
+            type="password"
+            placeholder="*********"
+            label="Password"
+            className={elW6}
+          />
           {errors.password?.message && <InputError message={errors.password.message} />}
-        </InputWrap>
-        <InputWrap>
+        </InputWrapFull>
+        <InputWrapFull>
           <InputGroup
             {...register('passwordConfirm')}
             type="password"
             placeholder="*********"
             label="Confirm Password"
+            className={elW6}
           />
           {errors.passwordConfirm?.message && <InputError message={errors.passwordConfirm.message} />}
-        </InputWrap>
+        </InputWrapFull>
+      </FormLayout>
+
+      <BodyText hasGreyText>Please provide an email address so we know who to contact about this account</BodyText>
+
+      <FormLayout className={elMb11}>
+        <InputWrapFull>
+          <Input {...register('email')} type="text" placeholder="Your email address" className={elW6} />
+          {errors.email?.message && <InputError message={errors.email.message} />}
+        </InputWrapFull>
       </FormLayout>
       <ButtonGroup alignment="center">
         <Button intent="default" type="button" onClick={closeModal}>

--- a/packages/data-warehouse/src/types/accounts.ts
+++ b/packages/data-warehouse/src/types/accounts.ts
@@ -16,6 +16,7 @@ export interface AccountModel {
 export interface AccountCreateModel {
   username: string
   password: string
+  email: string
   passwordConfirm?: string
   isAdmin: boolean
   devMode: boolean


### PR DESCRIPTION
- User will now be forced to enter email address for all data warehouse accounts so we have someone to contact if we detect odd activity or other reasons
- Fixes issue with text fields overlapping each other

New modal:
![image](https://github.com/user-attachments/assets/19fd7abf-aec9-479c-a574-55bad0fe881c)

