### PR TITLE
chore: deprecate warn for api-key-service

### DIFF
--- a/packages/api-key-service/src/api-keys/api-key-provider.ts
+++ b/packages/api-key-service/src/api-keys/api-key-provider.ts
@@ -1,5 +1,5 @@
 import { DataMapper, QueryIterator } from '@aws/dynamodb-data-mapper'
-import { Injectable } from '@nestjs/common'
+import { Injectable, NotImplementedException } from '@nestjs/common'
 import { ApiKeyModel } from '@reapit/api-key-verify'
 
 @Injectable()
@@ -45,6 +45,8 @@ export class ApiKeyProvider {
   }
 
   async getApiKeyByKey(apiKey: string): Promise<ApiKeyModel | undefined> {
+    console.warn('Oh no! Someone was using the api-key service afterall!')
+    throw new NotImplementedException()
     const result = await this.datamapper.query<ApiKeyModel>(
       ApiKeyModel,
       { apiKey },


### PR DESCRIPTION
Long story short. Am deploying this to the api-key service just in case someone is using it. It's very unlikely anyone is but just in case! Before I go and tear the resources down on poduction