### PR TITLE
chore: reenable devops-release for cognito mailer so we can deploy to ANZ

### DIFF
--- a/packages/cognito-custom-mail-lambda/package.json
+++ b/packages/cognito-custom-mail-lambda/package.json
@@ -12,7 +12,7 @@
     "build": "yarn generate-html && tsup && cd dist && zip -r app.zip app.js",
     "lint": "eslint --cache --ext=ts,tsx,js src",
     "check": "echo '...skipping...'",
-    "release": "echo '...deprecated... was previously \"devops-release && serverless deploy\"'",
+    "release": "devops-release",
     "release:devops": "devops-release",
     "deploy": "echo '...skipping...'",
     "publish": "echo '...skipping...'",


### PR DESCRIPTION
We inadvertently removed the ability to release the cognito mailer to the ANZ region. This PR fixes that