### PR TITLE
feat: rplt-512 allow dev.reapit unsecured domains to be registered against auth flow apps

### DIFF
--- a/packages/developer-portal/src/components/apps/edit/__tests__/__snapshots__/app-listing-tab.test.tsx.snap
+++ b/packages/developer-portal/src/components/apps/edit/__tests__/__snapshots__/app-listing-tab.test.tsx.snap
@@ -100,7 +100,7 @@ exports[`AppListingTab should match a snapshot 1`] = `
               classname=""
               id="test-static-id"
               name="launchUri"
-              placeholder="HTTPS or HTTP only for localhost"
+              placeholder="HTTPS or HTTP only for localhost/dev.reapit"
               type="text"
               value="Mock field value"
             />
@@ -629,7 +629,7 @@ exports[`AppListingTab should match a snapshot 1`] = `
             classname=""
             id="test-static-id"
             name="launchUri"
-            placeholder="HTTPS or HTTP only for localhost"
+            placeholder="HTTPS or HTTP only for localhost/dev.reapit"
             type="text"
             value="Mock field value"
           />
@@ -1278,7 +1278,7 @@ exports[`AppListingTab should match a snapshot with errors and messages 1`] = `
               classname="el-has-input-error"
               id="test-static-id"
               name="launchUri"
-              placeholder="HTTPS or HTTP only for localhost"
+              placeholder="HTTPS or HTTP only for localhost/dev.reapit"
               type="text"
             />
             <mock-styled.span
@@ -2019,7 +2019,7 @@ exports[`AppListingTab should match a snapshot with errors and messages 1`] = `
             classname="el-has-input-error"
             id="test-static-id"
             name="launchUri"
-            placeholder="HTTPS or HTTP only for localhost"
+            placeholder="HTTPS or HTTP only for localhost/dev.reapit"
             type="text"
           />
           <mock-styled.span

--- a/packages/developer-portal/src/components/apps/edit/form-schema/form-fields.ts
+++ b/packages/developer-portal/src/components/apps/edit/form-schema/form-fields.ts
@@ -109,7 +109,7 @@ export const formFields: Record<keyof AppEditFormSchema, InputGroupProps & { nam
   launchUri: {
     name: 'launchUri',
     label: 'Launch URI',
-    placeholder: 'HTTPS or HTTP only for localhost',
+    placeholder: 'HTTPS or HTTP only for localhost/dev.reapit',
     errorMessage: 'Invalid Launch URI',
     type: 'text',
   },

--- a/packages/developer-portal/src/components/apps/edit/form-schema/validation-schema.ts
+++ b/packages/developer-portal/src/components/apps/edit/form-schema/validation-schema.ts
@@ -7,7 +7,7 @@ import {
   emailRegex,
   isValidUrlWithCustomScheme,
   isValidLimitToClientIds,
-  whiteListLocalhostAndIsValidUrl,
+  isWhitelistedLocalDevelopmentUrlAndValidUrl,
   isValidHttpUrl,
   isValidHttpsUrl,
 } from '@reapit/utils-common'
@@ -82,7 +82,7 @@ export const appEditValidationSchema = object().shape({
           if (authFlow === USER_SESSION) {
             return schema.required(errorMessages.FIELD_REQUIRED).test({
               name: 'isValidLaunchUri',
-              test: whiteListLocalhostAndIsValidUrl,
+              test: isWhitelistedLocalDevelopmentUrlAndValidUrl,
               message: launchUri.errorMessage,
             })
           }
@@ -95,7 +95,7 @@ export const appEditValidationSchema = object().shape({
       message: launchUri.errorMessage,
       test: (value) => {
         if (!value) return true
-        return whiteListLocalhostAndIsValidUrl(value)
+        return isWhitelistedLocalDevelopmentUrlAndValidUrl(value)
       },
     }),
 
@@ -123,7 +123,7 @@ export const appEditValidationSchema = object().shape({
       message: homePage.errorMessage,
       test: (value) => {
         if (!value) return true
-        return whiteListLocalhostAndIsValidUrl(value) || isValidHttpUrl(value)
+        return isWhitelistedLocalDevelopmentUrlAndValidUrl(value) || isValidHttpUrl(value)
       },
     }),
 

--- a/packages/developer-portal/src/components/apps/new/__tests__/__snapshots__/helper-content.test.tsx.snap
+++ b/packages/developer-portal/src/components/apps/new/__tests__/__snapshots__/helper-content.test.tsx.snap
@@ -399,7 +399,7 @@ exports[`HelperContent should match a snapshot 1`] = `
             <a>
               Create React App Template
             </a>
-             however, any localhost (for local development), or https URI is acceptable. Please note, the URIs must match those in your app exactly, inclusive of white space and trailing slashes.
+             however, any localhost or dev.reapit (for local development), or https URI is acceptable. Please note, the URIs must match those in your app exactly, inclusive of white space and trailing slashes.
           </mock-styled.p>
         </div>
         <div
@@ -823,7 +823,7 @@ exports[`HelperContent should match a snapshot 1`] = `
           <a>
             Create React App Template
           </a>
-           however, any localhost (for local development), or https URI is acceptable. Please note, the URIs must match those in your app exactly, inclusive of white space and trailing slashes.
+           however, any localhost or dev.reapit (for local development), or https URI is acceptable. Please note, the URIs must match those in your app exactly, inclusive of white space and trailing slashes.
         </mock-styled.p>
       </div>
       <div

--- a/packages/developer-portal/src/components/apps/new/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/developer-portal/src/components/apps/new/__tests__/__snapshots__/index.test.tsx.snap
@@ -954,7 +954,7 @@ exports[`AppsNew should match a snapshot 1`] = `
                 <a>
                   Create React App Template
                 </a>
-                 however, any localhost (for local development), or https URI is acceptable. Please note, the URIs must match those in your app exactly, inclusive of white space and trailing slashes.
+                 however, any localhost or dev.reapit (for local development), or https URI is acceptable. Please note, the URIs must match those in your app exactly, inclusive of white space and trailing slashes.
               </mock-styled.p>
             </div>
             <div
@@ -1975,7 +1975,7 @@ exports[`AppsNew should match a snapshot 1`] = `
               <a>
                 Create React App Template
               </a>
-               however, any localhost (for local development), or https URI is acceptable. Please note, the URIs must match those in your app exactly, inclusive of white space and trailing slashes.
+               however, any localhost or dev.reapit (for local development), or https URI is acceptable. Please note, the URIs must match those in your app exactly, inclusive of white space and trailing slashes.
             </mock-styled.p>
           </div>
           <div
@@ -3062,7 +3062,7 @@ exports[`AppsNew should match snapshot for mobile view 1`] = `
                 <a>
                   Create React App Template
                 </a>
-                 however, any localhost (for local development), or https URI is acceptable. Please note, the URIs must match those in your app exactly, inclusive of white space and trailing slashes.
+                 however, any localhost or dev.reapit (for local development), or https URI is acceptable. Please note, the URIs must match those in your app exactly, inclusive of white space and trailing slashes.
               </mock-styled.p>
             </div>
             <div
@@ -4083,7 +4083,7 @@ exports[`AppsNew should match snapshot for mobile view 1`] = `
               <a>
                 Create React App Template
               </a>
-               however, any localhost (for local development), or https URI is acceptable. Please note, the URIs must match those in your app exactly, inclusive of white space and trailing slashes.
+               however, any localhost or dev.reapit (for local development), or https URI is acceptable. Please note, the URIs must match those in your app exactly, inclusive of white space and trailing slashes.
             </mock-styled.p>
           </div>
           <div

--- a/packages/developer-portal/src/components/apps/new/config.tsx
+++ b/packages/developer-portal/src/components/apps/new/config.tsx
@@ -55,7 +55,7 @@ export const appWizardSteps: AppNewWizardSteps = {
   [AppNewStepId.agencyCloudStep]: {
     headingText: 'Authentication',
     headerText:
-      'Please supply at least one redirect and logout uri. A non-https localhost uri is acceptable for quick start development.',
+      'Please supply at least one redirect and logout uri. A non-https localhost or dev.reapit uri is acceptable for quick start development.',
     iconName: 'userAuthInfographic',
   },
   [AppNewStepId.dataFeedStep]: {
@@ -73,13 +73,13 @@ export const appWizardSteps: AppNewWizardSteps = {
   [AppNewStepId.clientSideStep]: {
     headingText: 'Authentication',
     headerText:
-      'Please supply at least one redirect and logout uri. A non-https localhost uri is acceptable for quick start development.',
+      'Please supply at least one redirect and logout uri. A non-https localhost or dev.reapit uri is acceptable for quick start development.',
     iconName: 'userAuthInfographic',
   },
   [AppNewStepId.rcRedirectsStep]: {
     headingText: 'Authentication',
     headerText:
-      'Please supply at least one redirect and logout uri. A non-https localhost uri is acceptable for quick start development.',
+      'Please supply at least one redirect and logout uri. A non-https localhost or dev.reapit uri is acceptable for quick start development.',
     iconName: 'userAuthInfographic',
   },
   [AppNewStepId.websiteFeedStep]: {

--- a/packages/developer-portal/src/components/apps/new/helper-content.tsx
+++ b/packages/developer-portal/src/components/apps/new/helper-content.tsx
@@ -287,9 +287,9 @@ export const HelperContent: FC = () => {
         </BodyText>
         <BodyText hasGreyText>
           We have pre-populated the URIs that you need when using our{' '}
-          <a onClick={openNewPage(ExternalPages.craDocs)}>Create React App Template</a> however, any localhost (for
-          local development), or https URI is acceptable. Please note, the URIs must match those in your app exactly,
-          inclusive of white space and trailing slashes.
+          <a onClick={openNewPage(ExternalPages.craDocs)}>Create React App Template</a> however, any localhost or
+          dev.reapit (for local development), or https URI is acceptable. Please note, the URIs must match those in your
+          app exactly, inclusive of white space and trailing slashes.
         </BodyText>
       </div>
       <div className={cx(shouldShowStep(AppNewStepId.permissionsStep) ? elFadeIn : stepIsHidden)}>

--- a/packages/developer-portal/src/components/apps/new/index.tsx
+++ b/packages/developer-portal/src/components/apps/new/index.tsx
@@ -22,7 +22,7 @@ import { StepOptionsContent } from './step-options-content'
 import { yupResolver } from '@hookform/resolvers/yup'
 import { useForm, UseFormTrigger } from 'react-hook-form'
 import { object, SchemaOf, string, TestFunction } from 'yup'
-import { whiteListLocalhostAndIsValidUrl } from '@reapit/utils-common'
+import { isWhitelistedLocalDevelopmentUrlAndValidUrl } from '@reapit/utils-common'
 import errorMessages from '../../../constants/error-messages'
 import { AnyObject } from 'yup/lib/types'
 import { Marketplace } from '@reapit/foundations-ts-definitions'
@@ -54,15 +54,15 @@ const authCodeSchema: SchemaOf<CreateAppFormSchema> = object().shape({
     .trim()
     .required(errorMessages.FIELD_REQUIRED)
     .test({
-      test: whiteListLocalhostAndIsValidUrl as TestFunction<string | undefined, AnyObject>,
-      message: 'Should be a secure https url or http if localhost',
+      test: isWhitelistedLocalDevelopmentUrlAndValidUrl as TestFunction<string | undefined, AnyObject>,
+      message: 'Should be a secure https url or http if localhost or dev.reapit',
     }),
   signoutUris: string()
     .trim()
     .required(errorMessages.FIELD_REQUIRED)
     .test({
-      test: whiteListLocalhostAndIsValidUrl as TestFunction<string | undefined, AnyObject>,
-      message: 'Should be a secure https url or http if localhost',
+      test: isWhitelistedLocalDevelopmentUrlAndValidUrl as TestFunction<string | undefined, AnyObject>,
+      message: 'Should be a secure https url or http if localhost or dev.reapit',
     }),
   scopes: string().trim(),
 })

--- a/packages/utils-common/src/validators/__tests__/index.test.ts
+++ b/packages/utils-common/src/validators/__tests__/index.test.ts
@@ -7,6 +7,7 @@ import {
   isValidHttpUrl,
   whiteListLocalhostAndIsValidUrl,
   hasSpecialChars,
+  isWhitelistedLocalDevelopmentUrlAndValidUrl,
 } from '..'
 
 describe('isImageType', () => {
@@ -49,10 +50,12 @@ describe('isValidUrlWithCustomScheme', () => {
     const urls2 = 'myapp://link.com, http://localhost'
     const urls3 = 'https://link.com, http://localhost:9090'
     const urls4 = 'https://link.com,    https://localhost'
+    const urls5 = 'https://link.com, http://dev.reapit:8080'
     expect(isValidUrlWithCustomScheme(urls1)).toBe(true)
     expect(isValidUrlWithCustomScheme(urls2)).toBe(true)
     expect(isValidUrlWithCustomScheme(urls3)).toBe(true)
     expect(isValidUrlWithCustomScheme(urls4)).toBe(true)
+    expect(isValidUrlWithCustomScheme(urls5)).toBe(true)
   })
   it('should return false with invalid urls', () => {
     const urls1 = 'myapp:link.com, myapp://link2'
@@ -60,11 +63,13 @@ describe('isValidUrlWithCustomScheme', () => {
     const urls3 = 'http://link.com, http://localhost:9090'
     const urls4 = 'link-com,    https://localhost'
     const urls5 = 'app2://link-com, https://localhost'
+    const urls6 = 'link-com, http://dev.app'
     expect(isValidUrlWithCustomScheme(urls1)).toBe(false)
     expect(isValidUrlWithCustomScheme(urls2)).toBe(false)
     expect(isValidUrlWithCustomScheme(urls3)).toBe(false)
     expect(isValidUrlWithCustomScheme(urls4)).toBe(false)
     expect(isValidUrlWithCustomScheme(urls5)).toBe(false)
+    expect(isValidUrlWithCustomScheme(urls6)).toBe(false)
   })
 })
 
@@ -107,6 +112,20 @@ describe('whiteListLocalhostAndIsValidUrl', () => {
   it('invalid url test', () => {
     ;['invalid url test', 'htt://www.google.com'].forEach((url) =>
       expect(whiteListLocalhostAndIsValidUrl(url)).toBeFalsy(),
+    )
+  })
+})
+
+describe('isWhitelistedLocalDevelopmentUrlAndValidUrl', () => {
+  it('valid url test', () => {
+    ;['https://www.google.com', 'http://localhost:8080', 'http://dev.reapit', 'http://dev.reapit:8080'].forEach((url) =>
+      expect(isWhitelistedLocalDevelopmentUrlAndValidUrl(url)).toBeTruthy(),
+    )
+  })
+
+  it('invalid url test', () => {
+    ;['invalid url test', 'htt://www.google.com', 'http://invalid.app'].forEach((url) =>
+      expect(isWhitelistedLocalDevelopmentUrlAndValidUrl(url)).toBeFalsy(),
     )
   })
 })

--- a/packages/utils-common/src/validators/index.ts
+++ b/packages/utils-common/src/validators/index.ts
@@ -22,9 +22,9 @@ export const checkValidCustomScheme = (url: string): boolean => {
     return false
   }
   const [, protocol, link] = result
-  // allow http only for localhost
+  // allow http only for localhost and dev.reapit addresses
   if (protocol === 'http') {
-    return link.indexOf('localhost') === 0
+    return link.indexOf('localhost') === 0 || link.indexOf('dev.reapit') === 0
   }
 
   return !!protocol && !!link
@@ -48,6 +48,10 @@ export const isValidHttpUrl = (url: string) => {
 
 export const whiteListLocalhostAndIsValidUrl = (url: string) => {
   return isValidHttpsUrl(url) || /http?:\/\/localhost/.test(url)
+}
+
+export const isWhitelistedLocalDevelopmentUrlAndValidUrl = (url: string) => {
+  return isValidHttpsUrl(url) || /http?:\/\/localhost/.test(url) || /http?:\/\/dev.reapit/.test(url)
 }
 
 export const hasSpecialChars = (value: string): boolean => {


### PR DESCRIPTION
Allows developers to use http://dev.reapit addresses in their app configurations to allow workaround to localhost consent prompt with Auth0