### PR TITLE
chore: deprecate devops-release

### DIFF
--- a/packages/cognito-custom-mail-lambda/package.json
+++ b/packages/cognito-custom-mail-lambda/package.json
@@ -12,7 +12,7 @@
     "build": "yarn generate-html && tsup && cd dist && zip -r app.zip app.js",
     "lint": "eslint --cache --ext=ts,tsx,js src",
     "check": "echo '...skipping...'",
-    "release": "devops-release",
+    "release": "echo '...deprecated... was previously \"devops-release\"'",
     "release:devops": "devops-release",
     "deploy": "echo '...skipping...'",
     "publish": "echo '...skipping...'",


### PR DESCRIPTION
Removes automatic deployment of cognito custom mailer script as this is only required for ANZ for a short period

