### PR TITLE
chore: rplt-623 remove token rotation modal and update wizard text

### DIFF
--- a/packages/developer-portal/src/components/apps/new/__tests__/__snapshots__/helper-content.test.tsx.snap
+++ b/packages/developer-portal/src/components/apps/new/__tests__/__snapshots__/helper-content.test.tsx.snap
@@ -118,12 +118,11 @@ exports[`HelperContent should match a snapshot 1`] = `
               <p
                 class="el-text-base el-body-text el-has-grey-text"
               >
-                From November 2024, when registering an app that uses the authorisation code authentication flow, ensure it can handle rotating refresh tokens. For more information about this change,
+                When registering an app that uses the authorisation code authentication flow, it is important to understand refresh token behaviour. For more information about refresh tokens,
                  
                 <a>
                   please click here.
                 </a>
-                 Apps registered prior to this date are unaffected by this change.
               </p>
             </div>
           </div>
@@ -151,15 +150,11 @@ exports[`HelperContent should match a snapshot 1`] = `
           <p
             class="el-text-base el-body-text el-has-grey-text"
           >
-            From November 2024, when registering an app that uses the authorisation code authentication flow, ensure it can handle rotating refresh tokens. For more information about this change,
+            When registering an app that uses the authorisation code authentication flow, it is important to understand refresh token behaviour. For more information about refresh tokens,
              
-            <a
-              role="link"
-            >
+            <a>
               please click here.
             </a>
-             
-            Apps registered prior to this date are unaffected by this change.
           </p>
         </div>
         <div
@@ -285,15 +280,11 @@ exports[`HelperContent should match a snapshot 1`] = `
           <p
             class="el-text-base el-body-text el-has-grey-text"
           >
-            From November 2024, when registering an app that uses the authorisation code authentication flow, ensure it can handle rotating refresh tokens. For more information about this change,
+            When registering an app that uses the authorisation code authentication flow, it is important to understand refresh token behaviour. For more information about refresh tokens,
              
-            <a
-              role="link"
-            >
+            <a>
               please click here.
             </a>
-             
-            Apps registered prior to this date are unaffected by this change.
           </p>
         </div>
         <div
@@ -328,15 +319,11 @@ exports[`HelperContent should match a snapshot 1`] = `
           <p
             class="el-text-base el-body-text el-has-grey-text"
           >
-            From November 2024, when registering an app that uses the authorisation code authentication flow, ensure it can handle rotating refresh tokens. For more information about this change,
+            When registering an app that uses the authorisation code authentication flow, it is important to understand refresh token behaviour. For more information about refresh tokens,
              
-            <a
-              role="link"
-            >
+            <a>
               please click here.
             </a>
-             
-            Apps registered prior to this date are unaffected by this change.
           </p>
         </div>
         <div
@@ -382,15 +369,11 @@ exports[`HelperContent should match a snapshot 1`] = `
           <p
             class="el-text-base el-body-text el-has-grey-text"
           >
-            From November 2024, when registering an app that uses the authorisation code authentication flow, ensure it can handle rotating refresh tokens. For more information about this change,
+            When registering an app that uses the authorisation code authentication flow, it is important to understand refresh token behaviour. For more information about refresh tokens,
              
-            <a
-              role="link"
-            >
+            <a>
               please click here.
             </a>
-             
-            Apps registered prior to this date are unaffected by this change.
           </p>
         </div>
         <div
@@ -606,12 +589,11 @@ exports[`HelperContent should match a snapshot 1`] = `
             <p
               class="el-text-base el-body-text el-has-grey-text"
             >
-              From November 2024, when registering an app that uses the authorisation code authentication flow, ensure it can handle rotating refresh tokens. For more information about this change,
+              When registering an app that uses the authorisation code authentication flow, it is important to understand refresh token behaviour. For more information about refresh tokens,
                
               <a>
                 please click here.
               </a>
-               Apps registered prior to this date are unaffected by this change.
             </p>
           </div>
         </div>
@@ -639,15 +621,11 @@ exports[`HelperContent should match a snapshot 1`] = `
         <p
           class="el-text-base el-body-text el-has-grey-text"
         >
-          From November 2024, when registering an app that uses the authorisation code authentication flow, ensure it can handle rotating refresh tokens. For more information about this change,
+          When registering an app that uses the authorisation code authentication flow, it is important to understand refresh token behaviour. For more information about refresh tokens,
            
-          <a
-            role="link"
-          >
+          <a>
             please click here.
           </a>
-           
-          Apps registered prior to this date are unaffected by this change.
         </p>
       </div>
       <div
@@ -773,15 +751,11 @@ exports[`HelperContent should match a snapshot 1`] = `
         <p
           class="el-text-base el-body-text el-has-grey-text"
         >
-          From November 2024, when registering an app that uses the authorisation code authentication flow, ensure it can handle rotating refresh tokens. For more information about this change,
+          When registering an app that uses the authorisation code authentication flow, it is important to understand refresh token behaviour. For more information about refresh tokens,
            
-          <a
-            role="link"
-          >
+          <a>
             please click here.
           </a>
-           
-          Apps registered prior to this date are unaffected by this change.
         </p>
       </div>
       <div
@@ -816,15 +790,11 @@ exports[`HelperContent should match a snapshot 1`] = `
         <p
           class="el-text-base el-body-text el-has-grey-text"
         >
-          From November 2024, when registering an app that uses the authorisation code authentication flow, ensure it can handle rotating refresh tokens. For more information about this change,
+          When registering an app that uses the authorisation code authentication flow, it is important to understand refresh token behaviour. For more information about refresh tokens,
            
-          <a
-            role="link"
-          >
+          <a>
             please click here.
           </a>
-           
-          Apps registered prior to this date are unaffected by this change.
         </p>
       </div>
       <div
@@ -870,15 +840,11 @@ exports[`HelperContent should match a snapshot 1`] = `
         <p
           class="el-text-base el-body-text el-has-grey-text"
         >
-          From November 2024, when registering an app that uses the authorisation code authentication flow, ensure it can handle rotating refresh tokens. For more information about this change,
+          When registering an app that uses the authorisation code authentication flow, it is important to understand refresh token behaviour. For more information about refresh tokens,
            
-          <a
-            role="link"
-          >
+          <a>
             please click here.
           </a>
-           
-          Apps registered prior to this date are unaffected by this change.
         </p>
       </div>
       <div

--- a/packages/developer-portal/src/components/apps/new/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/developer-portal/src/components/apps/new/__tests__/__snapshots__/index.test.tsx.snap
@@ -676,12 +676,11 @@ exports[`AppsNew should match a snapshot 1`] = `
                   <p
                     class="el-text-base el-body-text el-has-grey-text"
                   >
-                    From November 2024, when registering an app that uses the authorisation code authentication flow, ensure it can handle rotating refresh tokens. For more information about this change,
+                    When registering an app that uses the authorisation code authentication flow, it is important to understand refresh token behaviour. For more information about refresh tokens,
                      
                     <a>
                       please click here.
                     </a>
-                     Apps registered prior to this date are unaffected by this change.
                   </p>
                 </div>
               </div>
@@ -709,15 +708,11 @@ exports[`AppsNew should match a snapshot 1`] = `
               <p
                 class="el-text-base el-body-text el-has-grey-text"
               >
-                From November 2024, when registering an app that uses the authorisation code authentication flow, ensure it can handle rotating refresh tokens. For more information about this change,
+                When registering an app that uses the authorisation code authentication flow, it is important to understand refresh token behaviour. For more information about refresh tokens,
                  
-                <a
-                  role="link"
-                >
+                <a>
                   please click here.
                 </a>
-                 
-                Apps registered prior to this date are unaffected by this change.
               </p>
             </div>
             <div
@@ -843,15 +838,11 @@ exports[`AppsNew should match a snapshot 1`] = `
               <p
                 class="el-text-base el-body-text el-has-grey-text"
               >
-                From November 2024, when registering an app that uses the authorisation code authentication flow, ensure it can handle rotating refresh tokens. For more information about this change,
+                When registering an app that uses the authorisation code authentication flow, it is important to understand refresh token behaviour. For more information about refresh tokens,
                  
-                <a
-                  role="link"
-                >
+                <a>
                   please click here.
                 </a>
-                 
-                Apps registered prior to this date are unaffected by this change.
               </p>
             </div>
             <div
@@ -886,15 +877,11 @@ exports[`AppsNew should match a snapshot 1`] = `
               <p
                 class="el-text-base el-body-text el-has-grey-text"
               >
-                From November 2024, when registering an app that uses the authorisation code authentication flow, ensure it can handle rotating refresh tokens. For more information about this change,
+                When registering an app that uses the authorisation code authentication flow, it is important to understand refresh token behaviour. For more information about refresh tokens,
                  
-                <a
-                  role="link"
-                >
+                <a>
                   please click here.
                 </a>
-                 
-                Apps registered prior to this date are unaffected by this change.
               </p>
             </div>
             <div
@@ -940,15 +927,11 @@ exports[`AppsNew should match a snapshot 1`] = `
               <p
                 class="el-text-base el-body-text el-has-grey-text"
               >
-                From November 2024, when registering an app that uses the authorisation code authentication flow, ensure it can handle rotating refresh tokens. For more information about this change,
+                When registering an app that uses the authorisation code authentication flow, it is important to understand refresh token behaviour. For more information about refresh tokens,
                  
-                <a
-                  role="link"
-                >
+                <a>
                   please click here.
                 </a>
-                 
-                Apps registered prior to this date are unaffected by this change.
               </p>
             </div>
             <div
@@ -1063,10 +1046,10 @@ exports[`AppsNew should match a snapshot 1`] = `
         />
         <div
           class="mocked-styled-147 el-mobile-controls"
-          id=":r5:"
+          id=":r4:"
         >
           <button
-            aria-controls=":r5:"
+            aria-controls=":r4:"
             class="el-floating-button el-intent-primary el-button"
           >
             <div
@@ -1767,12 +1750,11 @@ exports[`AppsNew should match a snapshot 1`] = `
                 <p
                   class="el-text-base el-body-text el-has-grey-text"
                 >
-                  From November 2024, when registering an app that uses the authorisation code authentication flow, ensure it can handle rotating refresh tokens. For more information about this change,
+                  When registering an app that uses the authorisation code authentication flow, it is important to understand refresh token behaviour. For more information about refresh tokens,
                    
                   <a>
                     please click here.
                   </a>
-                   Apps registered prior to this date are unaffected by this change.
                 </p>
               </div>
             </div>
@@ -1800,15 +1782,11 @@ exports[`AppsNew should match a snapshot 1`] = `
             <p
               class="el-text-base el-body-text el-has-grey-text"
             >
-              From November 2024, when registering an app that uses the authorisation code authentication flow, ensure it can handle rotating refresh tokens. For more information about this change,
+              When registering an app that uses the authorisation code authentication flow, it is important to understand refresh token behaviour. For more information about refresh tokens,
                
-              <a
-                role="link"
-              >
+              <a>
                 please click here.
               </a>
-               
-              Apps registered prior to this date are unaffected by this change.
             </p>
           </div>
           <div
@@ -1934,15 +1912,11 @@ exports[`AppsNew should match a snapshot 1`] = `
             <p
               class="el-text-base el-body-text el-has-grey-text"
             >
-              From November 2024, when registering an app that uses the authorisation code authentication flow, ensure it can handle rotating refresh tokens. For more information about this change,
+              When registering an app that uses the authorisation code authentication flow, it is important to understand refresh token behaviour. For more information about refresh tokens,
                
-              <a
-                role="link"
-              >
+              <a>
                 please click here.
               </a>
-               
-              Apps registered prior to this date are unaffected by this change.
             </p>
           </div>
           <div
@@ -1977,15 +1951,11 @@ exports[`AppsNew should match a snapshot 1`] = `
             <p
               class="el-text-base el-body-text el-has-grey-text"
             >
-              From November 2024, when registering an app that uses the authorisation code authentication flow, ensure it can handle rotating refresh tokens. For more information about this change,
+              When registering an app that uses the authorisation code authentication flow, it is important to understand refresh token behaviour. For more information about refresh tokens,
                
-              <a
-                role="link"
-              >
+              <a>
                 please click here.
               </a>
-               
-              Apps registered prior to this date are unaffected by this change.
             </p>
           </div>
           <div
@@ -2031,15 +2001,11 @@ exports[`AppsNew should match a snapshot 1`] = `
             <p
               class="el-text-base el-body-text el-has-grey-text"
             >
-              From November 2024, when registering an app that uses the authorisation code authentication flow, ensure it can handle rotating refresh tokens. For more information about this change,
+              When registering an app that uses the authorisation code authentication flow, it is important to understand refresh token behaviour. For more information about refresh tokens,
                
-              <a
-                role="link"
-              >
+              <a>
                 please click here.
               </a>
-               
-              Apps registered prior to this date are unaffected by this change.
             </p>
           </div>
           <div
@@ -2154,10 +2120,10 @@ exports[`AppsNew should match a snapshot 1`] = `
       />
       <div
         class="mocked-styled-147 el-mobile-controls"
-        id=":r5:"
+        id=":r4:"
       >
         <button
-          aria-controls=":r5:"
+          aria-controls=":r4:"
           class="el-floating-button el-intent-primary el-button"
         >
           <div
@@ -2246,55 +2212,6 @@ exports[`AppsNew should match snapshot for mobile view 1`] = `
     <div
       id="root"
     >
-      <div>
-        <div
-          class="el-is-active el-modal-bg"
-        />
-        <div
-          aria-describedby=":r6:"
-          aria-modal="true"
-          class="el-is-active el-modal"
-          role="dialog"
-        >
-          <div
-            class="mocked-styled-50 el-modal-header"
-          >
-            Important changes to refresh tokens
-          </div>
-          <div
-            class="mocked-styled-51 el-modal-body"
-            id=":r6:"
-          >
-            <p
-              class="el-text-base el-body-text el-has-grey-text"
-            >
-              From November 2024, when registering an app that uses the authorisation code authentication flow, ensure it can handle rotating refresh tokens. Apps registered prior to this date were given reusable refresh tokens from Reapit Connect. New apps will only be given single use refresh tokens as part of enhanced security updates.
-            </p>
-            <p
-              class="el-text-base el-body-text el-has-grey-text"
-            >
-              For more information about this change,
-               
-              <a>
-                please click here.
-              </a>
-               Any apps registered prior to this date are unaffected by this change.
-            </p>
-            <p
-              class="el-text-base el-body-text el-has-grey-text"
-            >
-              <button
-                class="el-intent-primary el-button"
-              >
-                <div
-                  class="mocked-styled-0 el-button-loader"
-                />
-                Close
-              </button>
-            </p>
-          </div>
-        </div>
-      </div>
       <div />
       <div />
       <div />
@@ -2973,12 +2890,11 @@ exports[`AppsNew should match snapshot for mobile view 1`] = `
                   <p
                     class="el-text-base el-body-text el-has-grey-text"
                   >
-                    From November 2024, when registering an app that uses the authorisation code authentication flow, ensure it can handle rotating refresh tokens. For more information about this change,
+                    When registering an app that uses the authorisation code authentication flow, it is important to understand refresh token behaviour. For more information about refresh tokens,
                      
                     <a>
                       please click here.
                     </a>
-                     Apps registered prior to this date are unaffected by this change.
                   </p>
                 </div>
               </div>
@@ -3006,15 +2922,11 @@ exports[`AppsNew should match snapshot for mobile view 1`] = `
               <p
                 class="el-text-base el-body-text el-has-grey-text"
               >
-                From November 2024, when registering an app that uses the authorisation code authentication flow, ensure it can handle rotating refresh tokens. For more information about this change,
+                When registering an app that uses the authorisation code authentication flow, it is important to understand refresh token behaviour. For more information about refresh tokens,
                  
-                <a
-                  role="link"
-                >
+                <a>
                   please click here.
                 </a>
-                 
-                Apps registered prior to this date are unaffected by this change.
               </p>
             </div>
             <div
@@ -3140,15 +3052,11 @@ exports[`AppsNew should match snapshot for mobile view 1`] = `
               <p
                 class="el-text-base el-body-text el-has-grey-text"
               >
-                From November 2024, when registering an app that uses the authorisation code authentication flow, ensure it can handle rotating refresh tokens. For more information about this change,
+                When registering an app that uses the authorisation code authentication flow, it is important to understand refresh token behaviour. For more information about refresh tokens,
                  
-                <a
-                  role="link"
-                >
+                <a>
                   please click here.
                 </a>
-                 
-                Apps registered prior to this date are unaffected by this change.
               </p>
             </div>
             <div
@@ -3183,15 +3091,11 @@ exports[`AppsNew should match snapshot for mobile view 1`] = `
               <p
                 class="el-text-base el-body-text el-has-grey-text"
               >
-                From November 2024, when registering an app that uses the authorisation code authentication flow, ensure it can handle rotating refresh tokens. For more information about this change,
+                When registering an app that uses the authorisation code authentication flow, it is important to understand refresh token behaviour. For more information about refresh tokens,
                  
-                <a
-                  role="link"
-                >
+                <a>
                   please click here.
                 </a>
-                 
-                Apps registered prior to this date are unaffected by this change.
               </p>
             </div>
             <div
@@ -3237,15 +3141,11 @@ exports[`AppsNew should match snapshot for mobile view 1`] = `
               <p
                 class="el-text-base el-body-text el-has-grey-text"
               >
-                From November 2024, when registering an app that uses the authorisation code authentication flow, ensure it can handle rotating refresh tokens. For more information about this change,
+                When registering an app that uses the authorisation code authentication flow, it is important to understand refresh token behaviour. For more information about refresh tokens,
                  
-                <a
-                  role="link"
-                >
+                <a>
                   please click here.
                 </a>
-                 
-                Apps registered prior to this date are unaffected by this change.
               </p>
             </div>
             <div
@@ -3360,10 +3260,10 @@ exports[`AppsNew should match snapshot for mobile view 1`] = `
         />
         <div
           class="mocked-styled-147 el-mobile-controls"
-          id=":rc:"
+          id=":ra:"
         >
           <button
-            aria-controls=":rc:"
+            aria-controls=":ra:"
             class="el-floating-button el-intent-primary el-button"
           >
             <div
@@ -4064,12 +3964,11 @@ exports[`AppsNew should match snapshot for mobile view 1`] = `
                 <p
                   class="el-text-base el-body-text el-has-grey-text"
                 >
-                  From November 2024, when registering an app that uses the authorisation code authentication flow, ensure it can handle rotating refresh tokens. For more information about this change,
+                  When registering an app that uses the authorisation code authentication flow, it is important to understand refresh token behaviour. For more information about refresh tokens,
                    
                   <a>
                     please click here.
                   </a>
-                   Apps registered prior to this date are unaffected by this change.
                 </p>
               </div>
             </div>
@@ -4097,15 +3996,11 @@ exports[`AppsNew should match snapshot for mobile view 1`] = `
             <p
               class="el-text-base el-body-text el-has-grey-text"
             >
-              From November 2024, when registering an app that uses the authorisation code authentication flow, ensure it can handle rotating refresh tokens. For more information about this change,
+              When registering an app that uses the authorisation code authentication flow, it is important to understand refresh token behaviour. For more information about refresh tokens,
                
-              <a
-                role="link"
-              >
+              <a>
                 please click here.
               </a>
-               
-              Apps registered prior to this date are unaffected by this change.
             </p>
           </div>
           <div
@@ -4231,15 +4126,11 @@ exports[`AppsNew should match snapshot for mobile view 1`] = `
             <p
               class="el-text-base el-body-text el-has-grey-text"
             >
-              From November 2024, when registering an app that uses the authorisation code authentication flow, ensure it can handle rotating refresh tokens. For more information about this change,
+              When registering an app that uses the authorisation code authentication flow, it is important to understand refresh token behaviour. For more information about refresh tokens,
                
-              <a
-                role="link"
-              >
+              <a>
                 please click here.
               </a>
-               
-              Apps registered prior to this date are unaffected by this change.
             </p>
           </div>
           <div
@@ -4274,15 +4165,11 @@ exports[`AppsNew should match snapshot for mobile view 1`] = `
             <p
               class="el-text-base el-body-text el-has-grey-text"
             >
-              From November 2024, when registering an app that uses the authorisation code authentication flow, ensure it can handle rotating refresh tokens. For more information about this change,
+              When registering an app that uses the authorisation code authentication flow, it is important to understand refresh token behaviour. For more information about refresh tokens,
                
-              <a
-                role="link"
-              >
+              <a>
                 please click here.
               </a>
-               
-              Apps registered prior to this date are unaffected by this change.
             </p>
           </div>
           <div
@@ -4328,15 +4215,11 @@ exports[`AppsNew should match snapshot for mobile view 1`] = `
             <p
               class="el-text-base el-body-text el-has-grey-text"
             >
-              From November 2024, when registering an app that uses the authorisation code authentication flow, ensure it can handle rotating refresh tokens. For more information about this change,
+              When registering an app that uses the authorisation code authentication flow, it is important to understand refresh token behaviour. For more information about refresh tokens,
                
-              <a
-                role="link"
-              >
+              <a>
                 please click here.
               </a>
-               
-              Apps registered prior to this date are unaffected by this change.
             </p>
           </div>
           <div
@@ -4451,10 +4334,10 @@ exports[`AppsNew should match snapshot for mobile view 1`] = `
       />
       <div
         class="mocked-styled-147 el-mobile-controls"
-        id=":rc:"
+        id=":ra:"
       >
         <button
-          aria-controls=":rc:"
+          aria-controls=":ra:"
           class="el-floating-button el-intent-primary el-button"
         >
           <div

--- a/packages/developer-portal/src/components/apps/new/helper-content.tsx
+++ b/packages/developer-portal/src/components/apps/new/helper-content.tsx
@@ -141,10 +141,9 @@ export const HelperContent: FC = () => {
               on the requirements, <a onClick={openNewPage(ExternalPages.acLaunchableDocs)}>please click here.</a>
             </BodyText>
             <BodyText hasGreyText>
-              From November 2024, when registering an app that uses the authorisation code authentication flow, ensure
-              it can handle rotating refresh tokens. For more information about this change,{' '}
-              <a onClick={openNewPage(ExternalPages.refreshTokenDocs)}>please click here.</a> Apps registered prior to
-              this date are unaffected by this change.
+              When registering an app that uses the authorisation code authentication flow, it is important to
+              understand refresh token behaviour. For more information about refresh tokens,{' '}
+              <a onClick={openNewPage(ExternalPages.refreshTokenDocs)}>please click here.</a>
             </BodyText>
           </div>
         </FlexContainer>
@@ -162,12 +161,9 @@ export const HelperContent: FC = () => {
           from within AgencyCloud.
         </BodyText>
         <BodyText hasGreyText>
-          From November 2024, when registering an app that uses the authorisation code authentication flow, ensure it
-          can handle rotating refresh tokens. For more information about this change,{' '}
-          <a onClick={openNewPage(ExternalPages.refreshTokenDocs)} role="link">
-            please click here.
-          </a>{' '}
-          Apps registered prior to this date are unaffected by this change.
+          When registering an app that uses the authorisation code authentication flow, it is important to understand
+          refresh token behaviour. For more information about refresh tokens,{' '}
+          <a onClick={openNewPage(ExternalPages.refreshTokenDocs)}>please click here.</a>
         </BodyText>
       </div>
       <div className={cx(shouldShowStep(AppNewStepId.dataFeedStep) ? elFadeIn : stepIsHidden)}>
@@ -233,12 +229,9 @@ export const HelperContent: FC = () => {
           to investigate which data sets and permissions you will need before getting started.
         </BodyText>
         <BodyText hasGreyText>
-          From November 2024, when registering an app that uses the authorisation code authentication flow, ensure it
-          can handle rotating refresh tokens. For more information about this change,{' '}
-          <a onClick={openNewPage(ExternalPages.refreshTokenDocs)} role="link">
-            please click here.
-          </a>{' '}
-          Apps registered prior to this date are unaffected by this change.
+          When registering an app that uses the authorisation code authentication flow, it is important to understand
+          refresh token behaviour. For more information about refresh tokens,{' '}
+          <a onClick={openNewPage(ExternalPages.refreshTokenDocs)}>please click here.</a>
         </BodyText>
       </div>
       <div className={cx(shouldShowStep(AppNewStepId.reapitConnectStep) ? elFadeIn : stepIsHidden)}>
@@ -255,12 +248,9 @@ export const HelperContent: FC = () => {
           <a onClick={openNewPage(ExternalPages.loginWithReapitDocs)}>visit here</a>
         </BodyText>
         <BodyText hasGreyText>
-          From November 2024, when registering an app that uses the authorisation code authentication flow, ensure it
-          can handle rotating refresh tokens. For more information about this change,{' '}
-          <a onClick={openNewPage(ExternalPages.refreshTokenDocs)} role="link">
-            please click here.
-          </a>{' '}
-          Apps registered prior to this date are unaffected by this change.
+          When registering an app that uses the authorisation code authentication flow, it is important to understand
+          refresh token behaviour. For more information about refresh tokens,{' '}
+          <a onClick={openNewPage(ExternalPages.refreshTokenDocs)}>please click here.</a>
         </BodyText>
       </div>
       <div className={cx(shouldShowStep(AppNewStepId.clientSideStep) ? elFadeIn : stepIsHidden)}>
@@ -281,12 +271,9 @@ export const HelperContent: FC = () => {
           development.
         </BodyText>
         <BodyText hasGreyText>
-          From November 2024, when registering an app that uses the authorisation code authentication flow, ensure it
-          can handle rotating refresh tokens. For more information about this change,{' '}
-          <a onClick={openNewPage(ExternalPages.refreshTokenDocs)} role="link">
-            please click here.
-          </a>{' '}
-          Apps registered prior to this date are unaffected by this change.
+          When registering an app that uses the authorisation code authentication flow, it is important to understand
+          refresh token behaviour. For more information about refresh tokens,{' '}
+          <a onClick={openNewPage(ExternalPages.refreshTokenDocs)}>please click here.</a>
         </BodyText>
       </div>
       <div className={cx(shouldShowStep(AppNewStepId.serverSideStep) ? elFadeIn : stepIsHidden)}>

--- a/packages/developer-portal/src/components/apps/new/index.tsx
+++ b/packages/developer-portal/src/components/apps/new/index.tsx
@@ -15,7 +15,7 @@ import {
   useMediaQuery,
   useModal,
 } from '@reapit/elements'
-import React, { Dispatch, FC, SetStateAction, MouseEvent, useEffect, KeyboardEvent, useState } from 'react'
+import React, { Dispatch, FC, SetStateAction, MouseEvent, useEffect, KeyboardEvent } from 'react'
 import { AppAuthFlow, AppNewStepId, getAppWizardStep } from './config'
 import { AppWizardState, useAppState } from '../state/use-app-state'
 import { ControlsContainer, StepContainer } from './__styles__'
@@ -43,7 +43,6 @@ import { NavigateFunction, useNavigate } from 'react-router-dom'
 import { HelperContent } from './helper-content'
 import { defaultAppWizardState } from '../state/defaults'
 import { Helper } from '../page/helper'
-import { ExternalPages, openNewPage } from '../../../utils/navigation'
 
 export interface CreateAppFormSchema {
   redirectUris?: string
@@ -230,32 +229,8 @@ export const AppsNewPage: FC = () => {
 
   const { headingText, headerText, iconName } = getAppWizardStep(currentStep)
 
-  const [refreshRotationModelIsOpen, setRefreshRotationModelIsOpen] = useState(true)
-
   return (
     <GridResponsive>
-      <Modal
-        isOpen={refreshRotationModelIsOpen}
-        title="Important changes to refresh tokens"
-        onModalClose={() => setRefreshRotationModelIsOpen(false)}
-      >
-        <BodyText hasGreyText>
-          From November 2024, when registering an app that uses the authorisation code authentication flow, ensure it
-          can handle rotating refresh tokens. Apps registered prior to this date were given reusable refresh tokens from
-          Reapit Connect. New apps will only be given single use refresh tokens as part of enhanced security updates.
-        </BodyText>
-        <BodyText hasGreyText>
-          For more information about this change,{' '}
-          <a onClick={openNewPage(ExternalPages.refreshTokenDocs)}>please click here.</a> Any apps registered prior to
-          this date are unaffected by this change.
-        </BodyText>
-        <BodyText hasGreyText>
-          <Button intent="primary" onClick={() => setRefreshRotationModelIsOpen(false)}>
-            Close
-          </Button>
-        </BodyText>
-      </Modal>
-
       <ColResponsive
         spanMobile={4}
         spanTablet={4}


### PR DESCRIPTION
- removes modal that popped up when registering a new app advising about refresh token changes
- updates wizard text to call out refresh token behaviour and points user to docs

Example
![image](https://github.com/user-attachments/assets/f1d2a23b-02d8-4bf7-9452-ee555780d071)
