### PR TITLE
feat: rplt-735 alter email subject when requesting power bi access in data warehouse app

### DIFF
--- a/packages/data-warehouse/src/components/network/network.tsx
+++ b/packages/data-warehouse/src/components/network/network.tsx
@@ -22,7 +22,7 @@ import { useNetworkState } from './use-network-state'
 export const Network: FC = () => {
   const { Modal, openModal, closeModal } = useModal()
   const { Modal: ModalBi, openModal: openModalBi, closeModal: closeModalBi, modalIsOpen: modalIsOpenBi } = useModal()
-  const { customerId, rulesLoading, rules, customersLoading } = useNetworkState()
+  const { customerId, rulesLoading, rules, customersLoading, organisationId, organisationName } = useNetworkState()
 
   return (
     <FlexContainer isFlexAuto>
@@ -77,7 +77,7 @@ export const Network: FC = () => {
               Close
             </Button>
             <a
-              href={`mailto:dwh@reapitfoundations.zendesk.com?subject=Data%20Warehouse%20PowerBI%20Setup%20Request%20For%20CustomerId%20${customerId}`}
+              href={`mailto:dwh@reapitfoundations.zendesk.com?subject=Data%20Warehouse%20PowerBI%20setup%20request%20for%20${organisationName} (${organisationId})`}
               target="_blank"
               rel="noreferrer"
             >

--- a/packages/data-warehouse/src/components/network/use-network-state.tsx
+++ b/packages/data-warehouse/src/components/network/use-network-state.tsx
@@ -20,6 +20,8 @@ export interface NetworkState {
   rulesLoading: boolean
   ipsLoading: boolean
   customerId: string | null
+  organisationId: string | null
+  organisationName: string | null
   networkSelected: NetworkSelected
   setNetworkSelected: Dispatch<SetStateAction<NetworkSelected>>
   ipsPageNumber: number
@@ -55,7 +57,8 @@ export const NetworkProvider: FC<PropsWithChildren> = ({ children }) => {
     ipId: null,
   })
 
-  const organisationId = connectSession?.loginIdentity?.orgId
+  const organisationId = connectSession?.loginIdentity?.orgId || null
+  const organisationName = connectSession?.loginIdentity?.orgName || null
 
   const [customers, customersLoading] = useReapitGet<PagedCustomersModel>({
     reapitConnectBrowserSession,
@@ -96,6 +99,8 @@ export const NetworkProvider: FC<PropsWithChildren> = ({ children }) => {
         rulesLoading,
         ipsLoading,
         customerId,
+        organisationId,
+        organisationName,
         networkSelected,
         setNetworkSelected,
         ipsPageNumber,


### PR DESCRIPTION
- Email subject now uses organisation name and id instead of internal customer reference which only the data warehouse api cares about. This makes it easier to internal staff to setup


