### PR TITLE
feat: added serialisation to pusher events

### DIFF
--- a/packages/deployment-service/src/entities/pipeline.entity.ts
+++ b/packages/deployment-service/src/entities/pipeline.entity.ts
@@ -37,6 +37,7 @@ export class PipelineEntity extends AbstractEntity implements PipelineModelInter
     cascade: ['remove', 'insert'],
     eager: true,
   })
+  @Type(() => RepositoryEntity)
   repository?: RepositoryEntity
 
   @OneToMany(() => PipelineRunnerEntity, (pipelineRunner) => pipelineRunner.pipeline)

--- a/packages/deployment-service/src/events/pusher-provider.test.ts
+++ b/packages/deployment-service/src/events/pusher-provider.test.ts
@@ -1,0 +1,106 @@
+import Pusher from 'pusher'
+import { PusherProvider } from './pusher-provider'
+import { PipelineEntity } from '../entities/pipeline.entity'
+
+const mockPusherInstance = {
+  trigger: jest.fn(),
+  triggerBatch: jest.fn(),
+}
+
+describe('PusherProvider', () => {
+  const provider = new PusherProvider(mockPusherInstance as unknown as Pusher)
+
+  describe('trigger', () => {
+    afterEach(() => {
+      jest.resetAllMocks()
+    })
+
+    it('class-transformer will return serialised PipelineEntity', async () => {
+      const pipeline = new PipelineEntity()
+      pipeline.repository = {
+        // @ts-ignore
+        installationId: '12345',
+        // @ts-ignore
+        repositoryId: '12345',
+      }
+      await provider.trigger('channel', 'event-name', pipeline)
+
+      expect(mockPusherInstance.trigger).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(String),
+        expect.objectContaining({
+          repository: expect.objectContaining({
+            installationId: 12345,
+            repositoryId: 12345,
+          }),
+        }),
+      )
+    })
+
+    it('class-transformer will ignore objects', async () => {
+      const obj = {
+        string: 'thisIsAString',
+        number: 12345,
+        date: new Date(),
+      }
+
+      await provider.trigger('channel', 'event-name', obj)
+
+      expect(mockPusherInstance.trigger).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(String),
+        expect.objectContaining({
+          string: 'thisIsAString',
+          number: 12345,
+        }),
+      )
+    })
+  })
+
+  describe('triggerArray', () => {
+    afterEach(() => {
+      jest.resetAllMocks()
+    })
+
+    it('class-transformer will return serialised PipelineEntity', async () => {
+      const pipeline = new PipelineEntity()
+      pipeline.repository = {
+        // @ts-ignore
+        installationId: '12345',
+        // @ts-ignore
+        repositoryId: '12345',
+      }
+      await provider.triggerArray([{ channel: 'channel', name: 'event-name', data: pipeline }])
+
+      expect(mockPusherInstance.triggerBatch).toHaveBeenCalledWith([
+        expect.objectContaining({
+          data: expect.objectContaining({
+            repository: expect.objectContaining({
+              installationId: 12345,
+              repositoryId: 12345,
+            }),
+          }),
+        }),
+      ])
+    })
+
+    it('class-transformer will ignore objects', async () => {
+      const obj = {
+        string: 'thisIsAString',
+        number: 12345,
+        date: new Date(),
+      }
+
+      await provider.triggerArray([{ channel: 'channel', name: 'event-name', data: obj }])
+
+      expect(mockPusherInstance.triggerBatch).toHaveBeenCalledWith([
+        expect.objectContaining({
+          data: expect.objectContaining({
+            string: 'thisIsAString',
+            number: 12345,
+          }),
+        }),
+      ])
+    })
+  })
+})

--- a/packages/deployment-service/src/events/pusher-provider.ts
+++ b/packages/deployment-service/src/events/pusher-provider.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common'
+import { instanceToPlain } from 'class-transformer'
 import Pusher, { Response } from 'pusher'
 
 @Injectable()
@@ -6,11 +7,16 @@ export class PusherProvider {
   constructor(private readonly pusher: Pusher) {}
 
   trigger<T extends any>(channel: string | string[], event: string, data: T): Promise<Response> {
-    return this.pusher.trigger(channel, event, data)
+    return this.pusher.trigger(channel, event, instanceToPlain(data))
   }
 
   triggerArray<T extends any>(entries: { channel: string; name: string; data: T }[]): Promise<Response> {
-    return this.pusher.triggerBatch(entries)
+    return this.pusher.triggerBatch(
+      entries.map((entry) => ({
+        ...entry,
+        data: instanceToPlain(entry.data),
+      })),
+    )
   }
 
   authenticate(socket_id: string, channel_name: string) {


### PR DESCRIPTION
In developer-portal. Pusher events are being consumed without serialisation which is resulting in repositories values being changed from a number to a string as a string from the database is returned as a number when making requests with http

