### PR TITLE
feat: iaas ui tweaks

### DIFF
--- a/packages/developer-portal/src/components/apps/pipeline/__tests__/__snapshots__/pipeline-controls.test.tsx.snap
+++ b/packages/developer-portal/src/components/apps/pipeline/__tests__/__snapshots__/pipeline-controls.test.tsx.snap
@@ -185,7 +185,7 @@ exports[`PipelineControls should match snapshot for route /apps/:appId/pipeline 
         <div
           class="el-text-base el-small-text el-has-grey-text"
         >
-          When you have a pipeline for your application, you can manage deployments from this page. Each table row refers to a deployment, and by expading the content, you can follow progress in real time.
+          When you have a pipeline for your application, you can manage deployments from this page. Each table row refers to a deployment. By expanding the content, you can follow progress in real time and download logs.
         </div>
         <div
           class="mocked-styled-2 el-button-group"
@@ -399,7 +399,7 @@ exports[`PipelineControls should match snapshot for route /apps/:appId/pipeline 
       <div
         class="el-text-base el-small-text el-has-grey-text"
       >
-        When you have a pipeline for your application, you can manage deployments from this page. Each table row refers to a deployment, and by expading the content, you can follow progress in real time.
+        When you have a pipeline for your application, you can manage deployments from this page. Each table row refers to a deployment. By expanding the content, you can follow progress in real time and download logs.
       </div>
       <div
         class="mocked-styled-2 el-button-group"
@@ -678,7 +678,7 @@ exports[`PipelineControls should match snapshot for route /apps/:appId/pipeline/
         <div
           class="el-text-base el-small-text el-has-grey-text"
         >
-          When you have a pipeline for your application, you can manage deployments from this page. Each table row refers to a deployment, and by expading the content, you can follow progress in real time.
+          When you have a pipeline for your application, you can manage deployments from this page. Each table row refers to a deployment. By expanding the content, you can follow progress in real time and download logs.
         </div>
         <div
           class="mocked-styled-2 el-button-group"
@@ -892,7 +892,7 @@ exports[`PipelineControls should match snapshot for route /apps/:appId/pipeline/
       <div
         class="el-text-base el-small-text el-has-grey-text"
       >
-        When you have a pipeline for your application, you can manage deployments from this page. Each table row refers to a deployment, and by expading the content, you can follow progress in real time.
+        When you have a pipeline for your application, you can manage deployments from this page. Each table row refers to a deployment. By expanding the content, you can follow progress in real time and download logs.
       </div>
       <div
         class="mocked-styled-2 el-button-group"
@@ -1177,7 +1177,7 @@ exports[`PipelineControls should match snapshot for route /apps/:appId/pipeline/
         <div
           class="el-text-base el-small-text el-has-grey-text"
         >
-          When you have a pipeline for your application, you can manage deployments from this page. Each table row refers to a deployment, and by expading the content, you can follow progress in real time.
+          When you have a pipeline for your application, you can manage deployments from this page. Each table row refers to a deployment. By expanding the content, you can follow progress in real time and download logs.
         </div>
         <div
           class="mocked-styled-2 el-button-group"
@@ -1391,7 +1391,7 @@ exports[`PipelineControls should match snapshot for route /apps/:appId/pipeline/
       <div
         class="el-text-base el-small-text el-has-grey-text"
       >
-        When you have a pipeline for your application, you can manage deployments from this page. Each table row refers to a deployment, and by expading the content, you can follow progress in real time.
+        When you have a pipeline for your application, you can manage deployments from this page. Each table row refers to a deployment. By expanding the content, you can follow progress in real time and download logs.
       </div>
       <div
         class="mocked-styled-2 el-button-group"
@@ -1673,7 +1673,7 @@ exports[`PipelineControls should match snapshot for route /apps/:appId/pipeline/
         <div
           class="el-text-base el-small-text el-has-grey-text"
         >
-          When you have a pipeline for your application, you can manage deployments from this page. Each table row refers to a deployment, and by expading the content, you can follow progress in real time.
+          When you have a pipeline for your application, you can manage deployments from this page. Each table row refers to a deployment. By expanding the content, you can follow progress in real time and download logs.
         </div>
         <div
           class="mocked-styled-2 el-button-group"
@@ -1887,7 +1887,7 @@ exports[`PipelineControls should match snapshot for route /apps/:appId/pipeline/
       <div
         class="el-text-base el-small-text el-has-grey-text"
       >
-        When you have a pipeline for your application, you can manage deployments from this page. Each table row refers to a deployment, and by expading the content, you can follow progress in real time.
+        When you have a pipeline for your application, you can manage deployments from this page. Each table row refers to a deployment. By expanding the content, you can follow progress in real time and download logs.
       </div>
       <div
         class="mocked-styled-2 el-button-group"
@@ -2178,7 +2178,7 @@ exports[`PipelineControls should match snapshot where pipeline is provisioning 1
         <div
           class="el-text-base el-small-text el-has-grey-text"
         >
-          When you have a pipeline for your application, you can manage deployments from this page. Each table row refers to a deployment, and by expading the content, you can follow progress in real time.
+          When you have a pipeline for your application, you can manage deployments from this page. Each table row refers to a deployment. By expanding the content, you can follow progress in real time and download logs.
         </div>
         <div
           class="mocked-styled-2 el-button-group"
@@ -2393,7 +2393,7 @@ exports[`PipelineControls should match snapshot where pipeline is provisioning 1
       <div
         class="el-text-base el-small-text el-has-grey-text"
       >
-        When you have a pipeline for your application, you can manage deployments from this page. Each table row refers to a deployment, and by expading the content, you can follow progress in real time.
+        When you have a pipeline for your application, you can manage deployments from this page. Each table row refers to a deployment. By expanding the content, you can follow progress in real time and download logs.
       </div>
       <div
         class="mocked-styled-2 el-button-group"
@@ -2682,7 +2682,7 @@ exports[`PipelineControls should match snapshot where there is no pipeline 1`] =
         <div
           class="el-text-base el-small-text el-has-grey-text"
         >
-          To get started with Reapit IAAS pipelines, first take the time to read the documentation. Then visit this page to configure your first pipeline.
+          To get started with Reapit IaaS pipelines, first take the time to read the documentation, then visit this page to configure your first pipeline.
         </div>
         <div
           class="mocked-styled-2 el-button-group"
@@ -2879,7 +2879,7 @@ exports[`PipelineControls should match snapshot where there is no pipeline 1`] =
       <div
         class="el-text-base el-small-text el-has-grey-text"
       >
-        To get started with Reapit IAAS pipelines, first take the time to read the documentation. Then visit this page to configure your first pipeline.
+        To get started with Reapit IaaS pipelines, first take the time to read the documentation, then visit this page to configure your first pipeline.
       </div>
       <div
         class="mocked-styled-2 el-button-group"

--- a/packages/developer-portal/src/components/apps/pipeline/__tests__/__snapshots__/pipeline-deployments-table.test.tsx.snap
+++ b/packages/developer-portal/src/components/apps/pipeline/__tests__/__snapshots__/pipeline-deployments-table.test.tsx.snap
@@ -104,7 +104,7 @@ exports[`PipelineDeploymentTable should match snapshot 1`] = `
                 class="mocked-styled-111 el-table-cell-content"
                 data-narrow-label="Created"
               >
-                20 Apr 2022 02:30:26
+                20 Apr 2022 14:30:26
               </div>
             </div>
             <div
@@ -569,7 +569,7 @@ exports[`PipelineDeploymentTable should match snapshot 1`] = `
               class="mocked-styled-111 el-table-cell-content"
               data-narrow-label="Created"
             >
-              20 Apr 2022 02:30:26
+              20 Apr 2022 14:30:26
             </div>
           </div>
           <div

--- a/packages/developer-portal/src/components/apps/pipeline/__tests__/__snapshots__/pipeline-new.test.tsx.snap
+++ b/packages/developer-portal/src/components/apps/pipeline/__tests__/__snapshots__/pipeline-new.test.tsx.snap
@@ -107,9 +107,33 @@ exports[`PipelineNew Should match snapshot 1`] = `
         />
       </div>
       <p
+        class="el-text-base el-body-text el-has-grey-text el-has-section-margin"
+      >
+        Setup the configuration below so that the pipeline knows how to build your application. The pipeline assumes that your application is a frontend application that uses either yarn or npm to run scripts declared in a package.json file. It also assumes that your application is bundled, and that the bundle is output to a local directory from which it can be deployed.
+      </p>
+      <p
         class="el-text-base el-body-text el-has-grey-text"
       >
-        Tell us about how we should build your application here. We assume that your application is a front end app and that, it uses either yarn or npm to run scripts declared in a package.json file. We assume also that your application is bundled and that bundle is output to a local directory that we can deploy for you.
+        <strong>
+          Deployment Branch
+        </strong>
+         is the branch from which push events will trigger a new deployment. typically main or master.
+      </p>
+      <p
+        class="el-text-base el-body-text el-has-grey-text"
+      >
+        <strong>
+          Build Command
+        </strong>
+         will be executed to prepare the application bundle, and should match the appropriate script in package.json.
+      </p>
+      <p
+        class="el-text-base el-body-text el-has-grey-text el-has-section-margin"
+      >
+        <strong>
+          Build Directory
+        </strong>
+         is the directory from which the bundle will be deployed, typically build or dist.
       </p>
       <form>
         <div
@@ -380,9 +404,33 @@ exports[`PipelineNew Should match snapshot 1`] = `
       />
     </div>
     <p
+      class="el-text-base el-body-text el-has-grey-text el-has-section-margin"
+    >
+      Setup the configuration below so that the pipeline knows how to build your application. The pipeline assumes that your application is a frontend application that uses either yarn or npm to run scripts declared in a package.json file. It also assumes that your application is bundled, and that the bundle is output to a local directory from which it can be deployed.
+    </p>
+    <p
       class="el-text-base el-body-text el-has-grey-text"
     >
-      Tell us about how we should build your application here. We assume that your application is a front end app and that, it uses either yarn or npm to run scripts declared in a package.json file. We assume also that your application is bundled and that bundle is output to a local directory that we can deploy for you.
+      <strong>
+        Deployment Branch
+      </strong>
+       is the branch from which push events will trigger a new deployment. typically main or master.
+    </p>
+    <p
+      class="el-text-base el-body-text el-has-grey-text"
+    >
+      <strong>
+        Build Command
+      </strong>
+       will be executed to prepare the application bundle, and should match the appropriate script in package.json.
+    </p>
+    <p
+      class="el-text-base el-body-text el-has-grey-text el-has-section-margin"
+    >
+      <strong>
+        Build Directory
+      </strong>
+       is the directory from which the bundle will be deployed, typically build or dist.
     </p>
     <form>
       <div
@@ -715,9 +763,33 @@ exports[`PipelineNew should match snapshot for mobile view 1`] = `
         />
       </div>
       <p
+        class="el-text-base el-body-text el-has-grey-text el-has-section-margin"
+      >
+        Setup the configuration below so that the pipeline knows how to build your application. The pipeline assumes that your application is a frontend application that uses either yarn or npm to run scripts declared in a package.json file. It also assumes that your application is bundled, and that the bundle is output to a local directory from which it can be deployed.
+      </p>
+      <p
         class="el-text-base el-body-text el-has-grey-text"
       >
-        Tell us about how we should build your application here. We assume that your application is a front end app and that, it uses either yarn or npm to run scripts declared in a package.json file. We assume also that your application is bundled and that bundle is output to a local directory that we can deploy for you.
+        <strong>
+          Deployment Branch
+        </strong>
+         is the branch from which push events will trigger a new deployment. typically main or master.
+      </p>
+      <p
+        class="el-text-base el-body-text el-has-grey-text"
+      >
+        <strong>
+          Build Command
+        </strong>
+         will be executed to prepare the application bundle, and should match the appropriate script in package.json.
+      </p>
+      <p
+        class="el-text-base el-body-text el-has-grey-text el-has-section-margin"
+      >
+        <strong>
+          Build Directory
+        </strong>
+         is the directory from which the bundle will be deployed, typically build or dist.
       </p>
       <form>
         <div
@@ -988,9 +1060,33 @@ exports[`PipelineNew should match snapshot for mobile view 1`] = `
       />
     </div>
     <p
+      class="el-text-base el-body-text el-has-grey-text el-has-section-margin"
+    >
+      Setup the configuration below so that the pipeline knows how to build your application. The pipeline assumes that your application is a frontend application that uses either yarn or npm to run scripts declared in a package.json file. It also assumes that your application is bundled, and that the bundle is output to a local directory from which it can be deployed.
+    </p>
+    <p
       class="el-text-base el-body-text el-has-grey-text"
     >
-      Tell us about how we should build your application here. We assume that your application is a front end app and that, it uses either yarn or npm to run scripts declared in a package.json file. We assume also that your application is bundled and that bundle is output to a local directory that we can deploy for you.
+      <strong>
+        Deployment Branch
+      </strong>
+       is the branch from which push events will trigger a new deployment. typically main or master.
+    </p>
+    <p
+      class="el-text-base el-body-text el-has-grey-text"
+    >
+      <strong>
+        Build Command
+      </strong>
+       will be executed to prepare the application bundle, and should match the appropriate script in package.json.
+    </p>
+    <p
+      class="el-text-base el-body-text el-has-grey-text el-has-section-margin"
+    >
+      <strong>
+        Build Directory
+      </strong>
+       is the directory from which the bundle will be deployed, typically build or dist.
     </p>
     <form>
       <div

--- a/packages/developer-portal/src/components/apps/pipeline/dns/__tests__/__snapshots__/dns-steps.test.tsx.snap
+++ b/packages/developer-portal/src/components/apps/pipeline/dns/__tests__/__snapshots__/dns-steps.test.tsx.snap
@@ -191,15 +191,46 @@ exports[`DNS Configuration Will show configuration page when dns info is returne
               </div>
             </div>
           </div>
-          <p
-            class="el-text-base el-body-text el-has-grey-text"
+          <div
+            class="el-intent-neutral el-is-active el-pn-is-full-width el-pn-is-inline el-persistent-notification"
+            role="status"
           >
-            If you are using a 
-            <code>
-              reapit.cloud
-            </code>
-             domain, we have automatically sent the above details to DevOps for them action. Once they have merged the DNS changes, the certificate will be issued and the status will update. The custom domain will then be available for use.
-          </p>
+            <div
+              class="el-pn-icon"
+              data-testid="close-icon"
+            >
+              <span
+                class="el-icon-new el-icon"
+                style="font-size: 1.25rem;"
+              >
+                <svg
+                  fill="none"
+                  height="1em"
+                  role="img"
+                  style="font-size: 1.25rem;"
+                  title="Icon image with name info"
+                  viewBox="0 0 24 24"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10A10 10 0 0 0 12 2m1.143 15.714h-2.286v-6h2.286zm-1.143-8a1.714 1.714 0 1 1 0-3.428 1.714 1.714 0 0 1 0 3.428"
+                    fill="currentColor"
+                  />
+                </svg>
+              </span>
+            </div>
+            <div
+              aria-live="polite"
+              class="el-pn-content"
+            >
+              If you are using a 
+              <code>
+                reapit.cloud
+              </code>
+               domain, we have automatically sent the above details to DevOps for them action. Once they have merged the DNS changes, the certificate will be issued and the status will update. The custom domain will then be available for use.
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -391,15 +422,46 @@ exports[`DNS Configuration Will show configuration page when dns info is returne
             </div>
           </div>
         </div>
-        <p
-          class="el-text-base el-body-text el-has-grey-text"
+        <div
+          class="el-intent-neutral el-is-active el-pn-is-full-width el-pn-is-inline el-persistent-notification"
+          role="status"
         >
-          If you are using a 
-          <code>
-            reapit.cloud
-          </code>
-           domain, we have automatically sent the above details to DevOps for them action. Once they have merged the DNS changes, the certificate will be issued and the status will update. The custom domain will then be available for use.
-        </p>
+          <div
+            class="el-pn-icon"
+            data-testid="close-icon"
+          >
+            <span
+              class="el-icon-new el-icon"
+              style="font-size: 1.25rem;"
+            >
+              <svg
+                fill="none"
+                height="1em"
+                role="img"
+                style="font-size: 1.25rem;"
+                title="Icon image with name info"
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10A10 10 0 0 0 12 2m1.143 15.714h-2.286v-6h2.286zm-1.143-8a1.714 1.714 0 1 1 0-3.428 1.714 1.714 0 0 1 0 3.428"
+                  fill="currentColor"
+                />
+              </svg>
+            </span>
+          </div>
+          <div
+            aria-live="polite"
+            class="el-pn-content"
+          >
+            If you are using a 
+            <code>
+              reapit.cloud
+            </code>
+             domain, we have automatically sent the above details to DevOps for them action. Once they have merged the DNS changes, the certificate will be issued and the status will update. The custom domain will then be available for use.
+          </div>
+        </div>
       </div>
     </div>
   </div>,

--- a/packages/developer-portal/src/components/apps/pipeline/dns/__tests__/__snapshots__/dns-steps.test.tsx.snap
+++ b/packages/developer-portal/src/components/apps/pipeline/dns/__tests__/__snapshots__/dns-steps.test.tsx.snap
@@ -14,15 +14,6 @@ exports[`DNS Configuration Will show configuration page when dns info is returne
         <div
           class="mocked-styled-135 el-input-wrap-full"
         >
-          <p
-            class="el-text-base el-body-text el-has-grey-text"
-          >
-            If you are using a 'reapit.cloud' domain, we have automatically sent the following details for DevOps to action. If you are using a custom domain, please copy the details below to verify your certificate.
-          </p>
-        </div>
-        <div
-          class="mocked-styled-135 el-input-wrap-full"
-        >
           <h2
             class="el-text-base el-subtitle"
           >
@@ -42,91 +33,172 @@ exports[`DNS Configuration Will show configuration page when dns info is returne
           </div>
         </div>
         <div
-          class="mocked-styled-136 el-input-wrap-half"
+          class="mocked-styled-135 el-input-wrap-full"
         >
           <h2
             class="el-text-base el-subtitle"
           >
-            Type
+            DNS Validation
           </h2>
           <p
             class="el-text-base el-body-text el-has-grey-text"
           >
-            CNAME
+            The following 
+            <code>
+              CNAME
+            </code>
+             record needs to be added to your domain's DNS settings to verify ownership ownership of the domain so that the SSL certificate can be issued.
           </p>
-        </div>
-        <div
-          class="mocked-styled-136 el-input-wrap-half"
-        >
+          <div
+            class="el-mb11 el-card-wrap"
+          >
+            <div
+              class="el-mb7 el-grid"
+            >
+              <div
+                class="mocked-styled-31 el-col"
+              >
+                <div
+                  class="el-flex-container"
+                >
+                  <div>
+                    <h2
+                      class="el-text-base el-subtitle el-has-no-margin"
+                    >
+                      Name
+                    </h2>
+                    <p
+                      class="el-text-base el-body-text el-has-grey-text"
+                    >
+                      dns record name
+                    </p>
+                  </div>
+                </div>
+                <button
+                  class="el-intent-neutral el-button"
+                >
+                  <div
+                    class="mocked-styled-0 el-button-loader"
+                  />
+                  Copy
+                </button>
+              </div>
+              <div
+                class="mocked-styled-31 el-col"
+              >
+                <div
+                  class="el-flex-container"
+                >
+                  <div>
+                    <h2
+                      class="el-text-base el-subtitle el-has-no-margin"
+                    >
+                      Value
+                    </h2>
+                    <p
+                      class="el-text-base el-body-text el-has-grey-text"
+                    >
+                      dns record value
+                    </p>
+                  </div>
+                </div>
+                <button
+                  class="el-intent-neutral el-button"
+                >
+                  <div
+                    class="mocked-styled-0 el-button-loader"
+                  />
+                  Copy
+                </button>
+              </div>
+            </div>
+          </div>
           <h2
             class="el-text-base el-subtitle"
           >
-            Name
+            Custom DNS Records
           </h2>
           <p
             class="el-text-base el-body-text el-has-grey-text"
           >
-            https://custom-domain.reapit.cloud
+            The following 
+            <code>
+              CNAME
+            </code>
+             record needs to be added to your domain's DNS settings to point your custom domain to the distribution deployed by this pipeline.
           </p>
-        </div>
-        <div
-          class="mocked-styled-136 el-input-wrap-half"
-        >
-          <h2
-            class="el-text-base el-subtitle"
+          <div
+            class="el-mb11 el-card-wrap"
           >
-            Value
-          </h2>
+            <div
+              class="el-mb7 el-grid"
+            >
+              <div
+                class="mocked-styled-31 el-col"
+              >
+                <div
+                  class="el-flex-container"
+                >
+                  <div>
+                    <h2
+                      class="el-text-base el-subtitle el-has-no-margin"
+                    >
+                      Name
+                    </h2>
+                    <p
+                      class="el-text-base el-body-text el-has-grey-text"
+                    >
+                      https://custom-domain.reapit.cloud
+                    </p>
+                  </div>
+                </div>
+                <button
+                  class="el-intent-neutral el-button"
+                >
+                  <div
+                    class="mocked-styled-0 el-button-loader"
+                  />
+                  Copy
+                </button>
+              </div>
+              <div
+                class="mocked-styled-31 el-col"
+              >
+                <div
+                  class="el-flex-container"
+                >
+                  <div>
+                    <h2
+                      class="el-text-base el-subtitle el-has-no-margin"
+                    >
+                      Value
+                    </h2>
+                    <p
+                      class="el-text-base el-body-text el-has-grey-text"
+                    >
+                      dfgdfgdfg.cloudfront.com
+                    </p>
+                  </div>
+                </div>
+                <button
+                  class="el-intent-neutral el-button"
+                >
+                  <div
+                    class="mocked-styled-0 el-button-loader"
+                  />
+                  Copy
+                </button>
+              </div>
+            </div>
+          </div>
           <p
             class="el-text-base el-body-text el-has-grey-text"
           >
-            dfgdfgdfg.cloudfront.com
-          </p>
-        </div>
-      </div>
-      <div
-        class="el-mb6 el-form-layout"
-      >
-        <div
-          class="mocked-styled-136 el-input-wrap-half"
-        >
-          <h2
-            class="el-text-base el-subtitle"
-          >
-            Type
-          </h2>
-          <p
-            class="el-text-base el-body-text el-has-grey-text"
-          >
-            CNAME
-          </p>
-        </div>
-        <div
-          class="mocked-styled-136 el-input-wrap-half"
-        >
-          <h2
-            class="el-text-base el-subtitle"
-          >
-            Name
-          </h2>
-          <p
-            class="el-text-base el-body-text el-has-grey-text"
-          >
-            dns record name
-          </p>
-        </div>
-        <div
-          class="mocked-styled-136 el-input-wrap-half"
-        >
-          <h2
-            class="el-text-base el-subtitle"
-          >
-             Value
-          </h2>
-          <p
-            class="el-text-base el-body-text el-has-grey-text"
-          >
-            dns record value
+            If you are using a 
+            <code>
+              reapit.cloud
+            </code>
+             domain, we have automatically sent the above details to DevOps for them action. Once they have merged the DNS changes, the certificate will be issued and the status will update. The custom domain will then be available for use.
           </p>
         </div>
       </div>
@@ -139,15 +211,6 @@ exports[`DNS Configuration Will show configuration page when dns info is returne
     <div
       class="el-mb6 el-form-layout"
     >
-      <div
-        class="mocked-styled-135 el-input-wrap-full"
-      >
-        <p
-          class="el-text-base el-body-text el-has-grey-text"
-        >
-          If you are using a 'reapit.cloud' domain, we have automatically sent the following details for DevOps to action. If you are using a custom domain, please copy the details below to verify your certificate.
-        </p>
-      </div>
       <div
         class="mocked-styled-135 el-input-wrap-full"
       >
@@ -170,91 +233,172 @@ exports[`DNS Configuration Will show configuration page when dns info is returne
         </div>
       </div>
       <div
-        class="mocked-styled-136 el-input-wrap-half"
+        class="mocked-styled-135 el-input-wrap-full"
       >
         <h2
           class="el-text-base el-subtitle"
         >
-          Type
+          DNS Validation
         </h2>
         <p
           class="el-text-base el-body-text el-has-grey-text"
         >
-          CNAME
+          The following 
+          <code>
+            CNAME
+          </code>
+           record needs to be added to your domain's DNS settings to verify ownership ownership of the domain so that the SSL certificate can be issued.
         </p>
-      </div>
-      <div
-        class="mocked-styled-136 el-input-wrap-half"
-      >
+        <div
+          class="el-mb11 el-card-wrap"
+        >
+          <div
+            class="el-mb7 el-grid"
+          >
+            <div
+              class="mocked-styled-31 el-col"
+            >
+              <div
+                class="el-flex-container"
+              >
+                <div>
+                  <h2
+                    class="el-text-base el-subtitle el-has-no-margin"
+                  >
+                    Name
+                  </h2>
+                  <p
+                    class="el-text-base el-body-text el-has-grey-text"
+                  >
+                    dns record name
+                  </p>
+                </div>
+              </div>
+              <button
+                class="el-intent-neutral el-button"
+              >
+                <div
+                  class="mocked-styled-0 el-button-loader"
+                />
+                Copy
+              </button>
+            </div>
+            <div
+              class="mocked-styled-31 el-col"
+            >
+              <div
+                class="el-flex-container"
+              >
+                <div>
+                  <h2
+                    class="el-text-base el-subtitle el-has-no-margin"
+                  >
+                    Value
+                  </h2>
+                  <p
+                    class="el-text-base el-body-text el-has-grey-text"
+                  >
+                    dns record value
+                  </p>
+                </div>
+              </div>
+              <button
+                class="el-intent-neutral el-button"
+              >
+                <div
+                  class="mocked-styled-0 el-button-loader"
+                />
+                Copy
+              </button>
+            </div>
+          </div>
+        </div>
         <h2
           class="el-text-base el-subtitle"
         >
-          Name
+          Custom DNS Records
         </h2>
         <p
           class="el-text-base el-body-text el-has-grey-text"
         >
-          https://custom-domain.reapit.cloud
+          The following 
+          <code>
+            CNAME
+          </code>
+           record needs to be added to your domain's DNS settings to point your custom domain to the distribution deployed by this pipeline.
         </p>
-      </div>
-      <div
-        class="mocked-styled-136 el-input-wrap-half"
-      >
-        <h2
-          class="el-text-base el-subtitle"
+        <div
+          class="el-mb11 el-card-wrap"
         >
-          Value
-        </h2>
+          <div
+            class="el-mb7 el-grid"
+          >
+            <div
+              class="mocked-styled-31 el-col"
+            >
+              <div
+                class="el-flex-container"
+              >
+                <div>
+                  <h2
+                    class="el-text-base el-subtitle el-has-no-margin"
+                  >
+                    Name
+                  </h2>
+                  <p
+                    class="el-text-base el-body-text el-has-grey-text"
+                  >
+                    https://custom-domain.reapit.cloud
+                  </p>
+                </div>
+              </div>
+              <button
+                class="el-intent-neutral el-button"
+              >
+                <div
+                  class="mocked-styled-0 el-button-loader"
+                />
+                Copy
+              </button>
+            </div>
+            <div
+              class="mocked-styled-31 el-col"
+            >
+              <div
+                class="el-flex-container"
+              >
+                <div>
+                  <h2
+                    class="el-text-base el-subtitle el-has-no-margin"
+                  >
+                    Value
+                  </h2>
+                  <p
+                    class="el-text-base el-body-text el-has-grey-text"
+                  >
+                    dfgdfgdfg.cloudfront.com
+                  </p>
+                </div>
+              </div>
+              <button
+                class="el-intent-neutral el-button"
+              >
+                <div
+                  class="mocked-styled-0 el-button-loader"
+                />
+                Copy
+              </button>
+            </div>
+          </div>
+        </div>
         <p
           class="el-text-base el-body-text el-has-grey-text"
         >
-          dfgdfgdfg.cloudfront.com
-        </p>
-      </div>
-    </div>
-    <div
-      class="el-mb6 el-form-layout"
-    >
-      <div
-        class="mocked-styled-136 el-input-wrap-half"
-      >
-        <h2
-          class="el-text-base el-subtitle"
-        >
-          Type
-        </h2>
-        <p
-          class="el-text-base el-body-text el-has-grey-text"
-        >
-          CNAME
-        </p>
-      </div>
-      <div
-        class="mocked-styled-136 el-input-wrap-half"
-      >
-        <h2
-          class="el-text-base el-subtitle"
-        >
-          Name
-        </h2>
-        <p
-          class="el-text-base el-body-text el-has-grey-text"
-        >
-          dns record name
-        </p>
-      </div>
-      <div
-        class="mocked-styled-136 el-input-wrap-half"
-      >
-        <h2
-          class="el-text-base el-subtitle"
-        >
-           Value
-        </h2>
-        <p
-          class="el-text-base el-body-text el-has-grey-text"
-        >
-          dns record value
+          If you are using a 
+          <code>
+            reapit.cloud
+          </code>
+           domain, we have automatically sent the above details to DevOps for them action. Once they have merged the DNS changes, the certificate will be issued and the status will update. The custom domain will then be available for use.
         </p>
       </div>
     </div>

--- a/packages/developer-portal/src/components/apps/pipeline/dns/dns-settings-page.tsx
+++ b/packages/developer-portal/src/components/apps/pipeline/dns/dns-settings-page.tsx
@@ -14,6 +14,7 @@ import {
   InputWrapFull,
   InputWrapHalf,
   InputWrapMed,
+  PersistentNotification,
   StatusIndicator,
   Subtitle,
   Table,
@@ -147,11 +148,11 @@ export const DnsSettingsPage: FC<{
               </Col>
             </Grid>
           </CardWrap>
-          <BodyText hasGreyText>
+          <PersistentNotification isExpanded intent="neutral" isInline isFullWidth>
             If you are using a <code>reapit.cloud</code> domain, we have automatically sent the above details to DevOps
             for them action. Once they have merged the DNS changes, the certificate will be issued and the status will
             update. The custom domain will then be available for use.
-          </BodyText>
+          </PersistentNotification>
         </InputWrapFull>
       </FormLayout>
     </>

--- a/packages/developer-portal/src/components/apps/pipeline/dns/dns-settings-page.tsx
+++ b/packages/developer-portal/src/components/apps/pipeline/dns/dns-settings-page.tsx
@@ -1,6 +1,8 @@
 import { cx } from '@linaria/core'
 import {
   BodyText,
+  Button,
+  ButtonGroup,
   elMb6,
   FlexContainer,
   FormLayout,
@@ -38,7 +40,7 @@ export const DnsSettingsPage: FC<{
           </FlexContainer>
         </InputWrapFull>
         <InputWrapFull>
-          <Subtitle>DNS Records</Subtitle>
+          <Subtitle>Certificate DNS Validation</Subtitle>
           <BodyText hasGreyText>
             The following records records need to be added to your domain&apos;s DNS settings. This is required to
             verify ownership of the domain so that the SSL certificate can be issued. If you are using a{' '}
@@ -46,8 +48,8 @@ export const DnsSettingsPage: FC<{
             action. Once they have merged the DNS changes, the certificate will be issued and the domain will be 
             available for use.
           </BodyText>
-          <Table className={cx(elMb6)} key={`${dnsInfo.customDomain}-${dnsInfo.cloudfrontUrl}`}>
-            <TableHeadersRow>
+        <Table>
+        <TableHeadersRow>
               <TableHeader>Type</TableHeader>
               <TableHeader>Name</TableHeader>
               <TableHeader>Value</TableHeader>
@@ -55,16 +57,50 @@ export const DnsSettingsPage: FC<{
             {dnsInfo.certificate?.DomainValidationOptions?.map((domain, index) => (
               <TableRow key={`${domain?.ResourceRecord?.Name}.${domain?.ResourceRecord?.Value}.${index}`}>
                 <TableCell>{domain?.ResourceRecord?.Type}</TableCell>
-                <TableCell>{domain?.ResourceRecord?.Name}</TableCell>
-                <TableCell>{domain?.ResourceRecord?.Value}</TableCell>
+                <TableCell>{domain?.ResourceRecord?.Name}
+                </TableCell>
+                <TableCell>{domain?.ResourceRecord?.Value}
+                </TableCell>
               </TableRow>
             ))}
+          </Table>
+          <FlexContainer>
+            <ButtonGroup>
+              <Button>Copy Name</Button>
+              <Button>Copy Value</Button>
+              </ButtonGroup>
+            </FlexContainer>
+<Subtitle>Custom DNS Records</Subtitle>
+            <BodyText hasGreyText>
+            The following records records need to be added to your domain&apos;s DNS settings. This is required to
+            verify ownership of the domain so that the SSL certificate can be issued. If you are using a{' '}
+            <code>reapit.cloud</code> domain, we have automatically sent the following details to DevOps for them
+            action. Once they have merged the DNS changes, the certificate will be issued and the domain will be 
+            available for use.
+          </BodyText>
+             <Table className={cx(elMb6)} key={`${dnsInfo.customDomain}-${dnsInfo.cloudfrontUrl}`}>
+            <TableHeadersRow>
+              <TableHeader>Type</TableHeader>
+              <TableHeader>Name</TableHeader>
+              <TableHeader>Value</TableHeader>
+            </TableHeadersRow>
             <TableRow>
               <TableCell>CNAME</TableCell>
-              <TableCell>{dnsInfo.customDomain}</TableCell>
-              <TableCell>{dnsInfo.cloudfrontUrl}</TableCell>
+              <TableCell>
+                {dnsInfo.customDomain}
+              </TableCell>
+              <TableCell>
+                {dnsInfo.cloudfrontUrl}
+              </TableCell>
             </TableRow>
           </Table>
+          <FlexContainer>
+            <ButtonGroup>
+            <Button>Copy Name</Button>
+              <Button>Copy Value</Button>
+            </ButtonGroup>
+            </FlexContainer>
+            
         </InputWrapFull>
       </FormLayout>
     </>

--- a/packages/developer-portal/src/components/apps/pipeline/dns/dns-settings-page.tsx
+++ b/packages/developer-portal/src/components/apps/pipeline/dns/dns-settings-page.tsx
@@ -65,8 +65,6 @@ export const DnsSettingsPage: FC<{
 
   return (
     <>
-    
-            
       <FormLayout className={cx(elMb6)}>
         <InputWrapFull>
           <Subtitle>Certificate Status</Subtitle>

--- a/packages/developer-portal/src/components/apps/pipeline/dns/dns-settings-page.tsx
+++ b/packages/developer-portal/src/components/apps/pipeline/dns/dns-settings-page.tsx
@@ -6,9 +6,17 @@ import {
   FormLayout,
   InputWrapFull,
   InputWrapHalf,
+  InputWrapMed,
+  InputWrapSmall,
   StatusIndicator,
   Subtitle,
+  Table,
+  TableCell,
+  TableHeader,
+  TableHeadersRow,
+  TableRow,
 } from '@reapit/elements'
+import { SubTitle } from 'chart.js'
 import React, { FC } from 'react'
 
 export const DnsSettingsPage: FC<{
@@ -23,51 +31,42 @@ export const DnsSettingsPage: FC<{
     <>
       <FormLayout className={cx(elMb6)}>
         <InputWrapFull>
-          <BodyText hasGreyText>
-            If you are using a &apos;reapit.cloud&apos; domain, we have automatically sent the following details for
-            DevOps to action. If you are using a custom domain, please copy the details below to verify your
-            certificate.
-          </BodyText>
-        </InputWrapFull>
-        <InputWrapFull>
           <Subtitle>Certificate Status</Subtitle>
           <FlexContainer isFlexRow isFlexAlignCenter>
             <StatusIndicator intent={certificateStatus === 'complete' ? 'success' : 'critical'} />
             <p style={{ textTransform: 'capitalize' }}>{certificateStatus}</p>
           </FlexContainer>
         </InputWrapFull>
-        <InputWrapHalf>
-          <Subtitle>Type</Subtitle>
-          <BodyText hasGreyText>CNAME</BodyText>
-        </InputWrapHalf>
-        <InputWrapHalf>
-          <Subtitle>Name</Subtitle>
-          <BodyText hasGreyText>{dnsInfo.customDomain}</BodyText>
-        </InputWrapHalf>
-        <InputWrapHalf>
-          <Subtitle>Value</Subtitle>
-          <BodyText hasGreyText>{dnsInfo.cloudfrontUrl}</BodyText>
-        </InputWrapHalf>
+        <InputWrapFull>
+          <Subtitle>DNS Records</Subtitle>
+          <BodyText hasGreyText>
+            The following records records need to be added to your domain&apos;s DNS settings. This is required to
+            verify ownership of the domain so that the SSL certificate can be issued. If you are using a{' '}
+            <code>reapit.cloud</code> domain, we have automatically sent the following details to DevOps for them
+            action. Once they have merged the DNS changes, the certificate will be issued and the domain will be 
+            available for use.
+          </BodyText>
+          <Table className={cx(elMb6)} key={`${dnsInfo.customDomain}-${dnsInfo.cloudfrontUrl}`}>
+            <TableHeadersRow>
+              <TableHeader>Type</TableHeader>
+              <TableHeader>Name</TableHeader>
+              <TableHeader>Value</TableHeader>
+            </TableHeadersRow>
+            {dnsInfo.certificate?.DomainValidationOptions?.map((domain, index) => (
+              <TableRow key={`${domain?.ResourceRecord?.Name}.${domain?.ResourceRecord?.Value}.${index}`}>
+                <TableCell>{domain?.ResourceRecord?.Type}</TableCell>
+                <TableCell>{domain?.ResourceRecord?.Name}</TableCell>
+                <TableCell>{domain?.ResourceRecord?.Value}</TableCell>
+              </TableRow>
+            ))}
+            <TableRow>
+              <TableCell>CNAME</TableCell>
+              <TableCell>{dnsInfo.customDomain}</TableCell>
+              <TableCell>{dnsInfo.cloudfrontUrl}</TableCell>
+            </TableRow>
+          </Table>
+        </InputWrapFull>
       </FormLayout>
-      {dnsInfo.certificate?.DomainValidationOptions?.map((domain, index) => (
-        <FormLayout
-          className={cx(elMb6)}
-          key={`${domain?.ResourceRecord?.Name}.${domain?.ResourceRecord?.Value}.${index}`}
-        >
-          <InputWrapHalf>
-            <Subtitle>Type</Subtitle>
-            <BodyText hasGreyText>{domain?.ResourceRecord?.Type}</BodyText>
-          </InputWrapHalf>
-          <InputWrapHalf>
-            <Subtitle>Name</Subtitle>
-            <BodyText hasGreyText>{domain?.ResourceRecord?.Name}</BodyText>
-          </InputWrapHalf>
-          <InputWrapHalf>
-            <Subtitle> Value</Subtitle>
-            <BodyText hasGreyText>{domain?.ResourceRecord?.Value}</BodyText>
-          </InputWrapHalf>
-        </FormLayout>
-      ))}
     </>
   )
 }

--- a/packages/developer-portal/src/components/apps/pipeline/dns/dns-settings-page.tsx
+++ b/packages/developer-portal/src/components/apps/pipeline/dns/dns-settings-page.tsx
@@ -3,13 +3,17 @@ import {
   BodyText,
   Button,
   ButtonGroup,
+  CardWrap,
+  Col,
+  elMb11,
   elMb6,
+  elMb7,
   FlexContainer,
   FormLayout,
+  Grid,
   InputWrapFull,
   InputWrapHalf,
   InputWrapMed,
-  InputWrapSmall,
   StatusIndicator,
   Subtitle,
   Table,
@@ -18,8 +22,36 @@ import {
   TableHeadersRow,
   TableRow,
 } from '@reapit/elements'
-import { SubTitle } from 'chart.js'
-import React, { FC } from 'react'
+import CopyToClipboard from 'react-copy-to-clipboard'
+import React, { Dispatch, FC, SetStateAction, useState } from 'react'
+
+export interface CopyState {
+  certName: string
+  certValue: string
+  distroName: string
+  distroValue: string
+}
+
+export const defaultCopyState = {
+  certName: 'Copy',
+  certValue: 'Copy',
+  distroName: 'Copy',
+  distroValue: 'Copy',
+}
+
+export const handleCopyCode = (setCopyState: Dispatch<SetStateAction<CopyState>>, key: keyof CopyState) => () => {
+  setCopyState({
+    ...defaultCopyState,
+    [key]: 'Copied',
+  })
+
+  setTimeout(() => {
+    setCopyState((currentState) => ({
+      ...currentState,
+      [key]: 'Copy',
+    }))
+  }, 5000)
+}
 
 export const DnsSettingsPage: FC<{
   dnsInfo: {
@@ -29,8 +61,12 @@ export const DnsSettingsPage: FC<{
   }
   certificateStatus: string
 }> = ({ dnsInfo, certificateStatus }) => {
+  const [copyState, setCopyState] = useState<CopyState>(defaultCopyState)
+
   return (
     <>
+    
+            
       <FormLayout className={cx(elMb6)}>
         <InputWrapFull>
           <Subtitle>Certificate Status</Subtitle>
@@ -40,67 +76,84 @@ export const DnsSettingsPage: FC<{
           </FlexContainer>
         </InputWrapFull>
         <InputWrapFull>
-          <Subtitle>Certificate DNS Validation</Subtitle>
+          <Subtitle>DNS Validation</Subtitle>
           <BodyText hasGreyText>
-            The following records records need to be added to your domain&apos;s DNS settings. This is required to
-            verify ownership of the domain so that the SSL certificate can be issued. If you are using a{' '}
-            <code>reapit.cloud</code> domain, we have automatically sent the following details to DevOps for them
-            action. Once they have merged the DNS changes, the certificate will be issued and the domain will be 
-            available for use.
+            The following <code>CNAME</code> record needs to be added to your domain&apos;s DNS settings to verify
+            ownership ownership of the domain so that the SSL certificate can be issued.
           </BodyText>
-        <Table>
-        <TableHeadersRow>
-              <TableHeader>Type</TableHeader>
-              <TableHeader>Name</TableHeader>
-              <TableHeader>Value</TableHeader>
-            </TableHeadersRow>
-            {dnsInfo.certificate?.DomainValidationOptions?.map((domain, index) => (
-              <TableRow key={`${domain?.ResourceRecord?.Name}.${domain?.ResourceRecord?.Value}.${index}`}>
-                <TableCell>{domain?.ResourceRecord?.Type}</TableCell>
-                <TableCell>{domain?.ResourceRecord?.Name}
-                </TableCell>
-                <TableCell>{domain?.ResourceRecord?.Value}
-                </TableCell>
-              </TableRow>
-            ))}
-          </Table>
-          <FlexContainer>
-            <ButtonGroup>
-              <Button>Copy Name</Button>
-              <Button>Copy Value</Button>
-              </ButtonGroup>
-            </FlexContainer>
-<Subtitle>Custom DNS Records</Subtitle>
-            <BodyText hasGreyText>
-            The following records records need to be added to your domain&apos;s DNS settings. This is required to
-            verify ownership of the domain so that the SSL certificate can be issued. If you are using a{' '}
-            <code>reapit.cloud</code> domain, we have automatically sent the following details to DevOps for them
-            action. Once they have merged the DNS changes, the certificate will be issued and the domain will be 
-            available for use.
+          {dnsInfo.certificate?.DomainValidationOptions?.map((domain, index) => (
+            <CardWrap
+              className={elMb11}
+              key={`${domain?.ResourceRecord?.Name}.${domain?.ResourceRecord?.Value}.${index}`}
+            >
+              <Grid className={cx(elMb7)}>
+                <Col>
+                  <FlexContainer>
+                    <div>
+                      <Subtitle hasNoMargin>Name</Subtitle>
+                      <BodyText hasGreyText>{domain?.ResourceRecord?.Name}</BodyText>
+                    </div>
+                  </FlexContainer>
+                  <CopyToClipboard
+                    text={domain?.ResourceRecord?.Name}
+                    onCopy={handleCopyCode(setCopyState, 'certName')}
+                  >
+                    <Button intent="default">{copyState.certName}</Button>
+                  </CopyToClipboard>
+                </Col>
+                <Col>
+                  <FlexContainer>
+                    <div>
+                      <Subtitle hasNoMargin>Value</Subtitle>
+                      <BodyText hasGreyText>{domain?.ResourceRecord?.Value}</BodyText>
+                    </div>
+                  </FlexContainer>
+                  <CopyToClipboard
+                    text={domain?.ResourceRecord?.Value}
+                    onCopy={handleCopyCode(setCopyState, 'certValue')}
+                  >
+                    <Button intent="default">{copyState.certValue}</Button>
+                  </CopyToClipboard>
+                </Col>
+              </Grid>
+            </CardWrap>
+          ))}
+          <Subtitle>Custom DNS Records</Subtitle>
+          <BodyText hasGreyText>
+            The following <code>CNAME</code> record needs to be added to your domain&apos;s DNS settings to point your
+            custom domain to the distribution deployed by this pipeline.
           </BodyText>
-             <Table className={cx(elMb6)} key={`${dnsInfo.customDomain}-${dnsInfo.cloudfrontUrl}`}>
-            <TableHeadersRow>
-              <TableHeader>Type</TableHeader>
-              <TableHeader>Name</TableHeader>
-              <TableHeader>Value</TableHeader>
-            </TableHeadersRow>
-            <TableRow>
-              <TableCell>CNAME</TableCell>
-              <TableCell>
-                {dnsInfo.customDomain}
-              </TableCell>
-              <TableCell>
-                {dnsInfo.cloudfrontUrl}
-              </TableCell>
-            </TableRow>
-          </Table>
-          <FlexContainer>
-            <ButtonGroup>
-            <Button>Copy Name</Button>
-              <Button>Copy Value</Button>
-            </ButtonGroup>
-            </FlexContainer>
-            
+          <CardWrap className={elMb11}>
+            <Grid className={cx(elMb7)}>
+              <Col>
+                <FlexContainer>
+                  <div>
+                    <Subtitle hasNoMargin>Name</Subtitle>
+                    <BodyText hasGreyText>{dnsInfo.customDomain}</BodyText>
+                  </div>
+                </FlexContainer>
+                <CopyToClipboard text={dnsInfo.customDomain} onCopy={handleCopyCode(setCopyState, 'distroName')}>
+                  <Button intent="default">{copyState.distroName}</Button>
+                </CopyToClipboard>
+              </Col>
+              <Col>
+                <FlexContainer>
+                  <div>
+                    <Subtitle hasNoMargin>Value</Subtitle>
+                    <BodyText hasGreyText>{dnsInfo.cloudfrontUrl}</BodyText>
+                  </div>
+                </FlexContainer>
+                <CopyToClipboard text={dnsInfo.cloudfrontUrl} onCopy={handleCopyCode(setCopyState, 'distroValue')}>
+                  <Button intent="default">{copyState.distroValue}</Button>
+                </CopyToClipboard>
+              </Col>
+            </Grid>
+          </CardWrap>
+          <BodyText hasGreyText>
+            If you are using a <code>reapit.cloud</code> domain, we have automatically sent the above details to DevOps
+            for them action. Once they have merged the DNS changes, the certificate will be issued and the status will
+            update. The custom domain will then be available for use.
+          </BodyText>
         </InputWrapFull>
       </FormLayout>
     </>

--- a/packages/developer-portal/src/components/apps/pipeline/dns/dns-uki-success-modal.tsx
+++ b/packages/developer-portal/src/components/apps/pipeline/dns/dns-uki-success-modal.tsx
@@ -9,9 +9,9 @@ export const DnsUKISuccessModal: FC<{ modalIsOpen: boolean; onModalClose: () => 
     <Modal isOpen={modalIsOpen} onModalClose={onModalClose}>
       <Subtitle>Success</Subtitle>
       <BodyText>
-        We have successfully created the custom domain certificate. As you are using a ‘reapit.cloud’ domain, we have
-        automatically provided the details to verify/register the certificate to the DevOps team. Once they have
-        completed the setup, the certificate status will be updated and your domain will be live.
+        We have successfully created the custom domain certificate. As you are using a <code>reapit.cloud</code>
+        domain, we have automatically provided the details to verify/register the certificate to the DevOps team. Once
+        they have completed the setup, the certificate status will be updated and your domain will be live.
       </BodyText>
       <Button intent="secondary" onClick={onModalClose}>
         Close

--- a/packages/developer-portal/src/components/apps/pipeline/pipeline-configure/pipeline-configure.tsx
+++ b/packages/developer-portal/src/components/apps/pipeline/pipeline-configure/pipeline-configure.tsx
@@ -10,9 +10,22 @@ export const PipelineConfigure: FC = () => {
     <>
       {!location.pathname.includes('new') && <PipelineTabs />}
       <BodyText hasGreyText>
-        Tell us about how we should build your application here. We assume that your application is a front end app and
-        that, it uses either yarn or npm to run scripts declared in a package.json file. We assume also that your
-        application is bundled and that bundle is output to a local directory that we can deploy for you.
+        Setup the configuration below so that the pipeline knows how to build your application. The pipeline assumes
+        that your application is a frontend application that uses either yarn or npm to run scripts declared in a
+        package.json file. It also assumes that your application is bundled, and that the bundle is output to a local
+        directory from which it can be deployed.
+      </BodyText>
+      <BodyText hasGreyText>
+        <strong>Deployment Branch</strong> is the branch from which push events will trigger a new deployment. typically
+        main or master.
+      </BodyText>
+      <BodyText hasGreyText>
+        <strong>Build Command</strong> will be executed to prepare the application bundle, and should match the
+        appropriate script in package.json.
+      </BodyText>
+      <BodyText hasGreyText hasSectionMargin>
+        <strong>Build Directory</strong> is the directory from which the bundle will be deployed, typically build or
+        dist.
       </BodyText>
       <PipelineConfigureForm />
     </>

--- a/packages/developer-portal/src/components/apps/pipeline/pipeline-configure/pipeline-configure.tsx
+++ b/packages/developer-portal/src/components/apps/pipeline/pipeline-configure/pipeline-configure.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react'
-import { BodyText, Subtitle } from '@reapit/elements'
+import { BodyText } from '@reapit/elements'
 import { PipelineTabs } from './../pipeline-tabs'
 import { PipelineConfigureForm } from './pipeline-configure-form'
 import { useLocation } from 'react-router'

--- a/packages/developer-portal/src/components/apps/pipeline/pipeline-configure/pipeline-configure.tsx
+++ b/packages/developer-portal/src/components/apps/pipeline/pipeline-configure/pipeline-configure.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react'
-import { BodyText } from '@reapit/elements'
+import { BodyText, Subtitle } from '@reapit/elements'
 import { PipelineTabs } from './../pipeline-tabs'
 import { PipelineConfigureForm } from './pipeline-configure-form'
 import { useLocation } from 'react-router'
@@ -9,7 +9,7 @@ export const PipelineConfigure: FC = () => {
   return (
     <>
       {!location.pathname.includes('new') && <PipelineTabs />}
-      <BodyText hasGreyText>
+      <BodyText hasGreyText hasSectionMargin>
         Setup the configuration below so that the pipeline knows how to build your application. The pipeline assumes
         that your application is a frontend application that uses either yarn or npm to run scripts declared in a
         package.json file. It also assumes that your application is bundled, and that the bundle is output to a local

--- a/packages/developer-portal/src/components/apps/pipeline/pipeline-controls.tsx
+++ b/packages/developer-portal/src/components/apps/pipeline/pipeline-controls.tsx
@@ -97,6 +97,8 @@ export const PipelineControls: FC = () => {
   const { appPipeline, setAppPipelineSaving, setAppPipelineDeploying } = appPipelineState
   const { pathname } = location
   const isConfigPage = pathname.includes('new') || pathname.includes('configure')
+  const isEnvironmentPage = pathname.includes('environment')
+  const isDnsPage = pathname.includes('dns')
   const { appDetail, appsDetailRefresh, appRefreshRevisions } = appsDataState
   const developerId = connectSession?.loginIdentity.developerId ?? null
   const isValidPipeline = validateConfig(appPipeline)
@@ -161,17 +163,28 @@ export const PipelineControls: FC = () => {
       <Subtitle>Pipeline</Subtitle>
       {isConfigPage ? (
         <SmallText tag="div" hasGreyText>
-          When you create an app, we create a pre-provisioned pipeline for your app. You should configure your build
-          steps on this page before using the deployments page to manage your releases to our infra.
+          When you create an app, a pipeline is pre-provisioned. You should configure your build steps on this page
+          before using the deployments page to manage your releases to our infrastructure.
+        </SmallText>
+      ) : isEnvironmentPage ? (
+        <SmallText tag="div" hasGreyText>
+          You may need to set up environment variables for your application. These are key-value pairs that will be
+          injected into your application at build time. You can set up environment variables for your application on
+          this page.
+        </SmallText>
+      ) : isDnsPage ? (
+        <SmallText tag="div" hasGreyText>
+          Configure a custom domain for your application from this page. You will need to setup CNAME records in your
+          DNS database which will be presented here.
         </SmallText>
       ) : appPipeline ? (
         <SmallText tag="div" hasGreyText>
           When you have a pipeline for your application, you can manage deployments from this page. Each table row
-          refers to a deployment, and by expading the content, you can follow progress in real time.
+          refers to a deployment. By expanding the content, you can follow progress in real time and download logs.
         </SmallText>
       ) : (
         <SmallText tag="div" hasGreyText>
-          To get started with Reapit IAAS pipelines, first take the time to read the documentation. Then visit this page
+          To get started with Reapit IaaS pipelines, first take the time to read the documentation, then visit this page
           to configure your first pipeline.
         </SmallText>
       )}
@@ -200,7 +213,7 @@ export const PipelineControls: FC = () => {
           >
             Provision
           </Button>
-        ) : appPipeline && !isConfigPage && isValidPipeline ? (
+        ) : appPipeline && !isConfigPage && isValidPipeline && !isDnsPage && !isEnvironmentPage ? (
           <>
             <Button
               loading={pipelineRunnerLoading || appPipeline.buildStatus === 'IN_PROGRESS'}
@@ -221,7 +234,7 @@ export const PipelineControls: FC = () => {
             Configure
           </Button>
         ) : null}
-        {appPipeline && (
+        {appPipeline && !isConfigPage && !isDnsPage && !isEnvironmentPage && (
           <Button
             loading={deleteLoading}
             intent="danger"

--- a/packages/developer-portal/src/components/apps/pipeline/pipeline-environment.tsx
+++ b/packages/developer-portal/src/components/apps/pipeline/pipeline-environment.tsx
@@ -128,16 +128,16 @@ export const PipelineEnvironment = () => {
     <>
       <PipelineTabs />
       <BodyText hasGreyText>
-        You can add your Environment variables for your application here. If you supply any key value pair we will write
-        them to the process.ENV object at compile time when building your app.
+        You can add your <strong>Environment Variables</strong> for your application here. If you supply any key value
+        pair it will be written to the <code>process.ENV</code> object at compile time when building your app.
       </BodyText>
       <BodyText hasGreyText>
-        All variables are stored in a secure and encrypted format however, if you are building a web app environment
+        All variables are stored in a secure and encrypted format, however if you are building a web app environment
         variables are inherently insecure. As such, you should only store values that can be exposed on the client side.
       </BodyText>
       <BodyText hasGreyText>
-        Currently we do not surface your variables over an API when you have stored them for security reasons. If you
-        need to confirm a variable value, we would advise updating it and re-deploying your app.
+        Currently your Environment Variables are not exposed over an API once you have stored them for security reasons.
+        If you need to confirm a variable value, it is advised to update it and re-deploy the application.
       </BodyText>
       {isFetching ? (
         <Loader />

--- a/packages/developer-portal/src/utils/date-time.ts
+++ b/packages/developer-portal/src/utils/date-time.ts
@@ -1,4 +1,4 @@
 import dayjs from 'dayjs'
 
-export const isoDateToHuman = (isoDateStr: string) => dayjs(isoDateStr).format('DD MMM YYYY hh:mm:ss')
-export const dateToHuman = (date: Date) => dayjs(date).format('DD MMM YYYY hh:mm:ss')
+export const isoDateToHuman = (isoDateStr: string) => dayjs(isoDateStr).format('DD MMM YYYY HH:mm:ss')
+export const dateToHuman = (date: Date) => dayjs(date).format('DD MMM YYYY HH:mm:ss')


### PR DESCRIPTION
This PR introduces a number of minor tweaks to the look and feel of the IaaS pages in the Developer Portal:

1) DateTimes now displayed in 24hr format. It's a bit weird seeing "02:10:00" when it was done in the afternoon:

![image](https://github.com/user-attachments/assets/2fda3ba9-fcbd-42dc-b79f-45b8caae6527)


2) A number of wording adjustments. Trying to drop the use of "we" and so on to make it read a bit more professionally
3) Hides the Deploy and Delete Pipeline buttons when you're not on the Deployment tab
4) Reworks the Custom DNS tab to:
  - Separate the DNS information for certification validation and cloudfront forwarding. Includes helper text above each section
  - Adds Copy functionality for each part of each DNS record so it's easy for developers to copy the values shown on screen
  
![image](https://github.com/user-attachments/assets/971cd24e-601a-4374-a8ab-1080fc2f154d)

![image](https://github.com/user-attachments/assets/5b8f3819-4408-49d4-812d-13a4e18b76f9)


5) Adds more descriptive text to the Configure and Environment Variables tabs
 
![image](https://github.com/user-attachments/assets/7b00edbb-bc9e-45a6-bd92-8fd8ba2895b9)

![image](https://github.com/user-attachments/assets/dff504eb-bc2f-416a-99ca-36619045a420)




