### PR TITLE
feat: rplt-898 no longer include office group query string parameter

### DIFF
--- a/packages/admin-portal/src/components/installations/index.tsx
+++ b/packages/admin-portal/src/components/installations/index.tsx
@@ -113,7 +113,6 @@ export const Installations: FC = () => {
       action: getActions[GetActionNames.getInstallations],
       queryParams: {
         ...formatFilters(installationsFilters),
-        includeOfficeGroups: true,
         pageNumber,
         pageSize,
       },


### PR DESCRIPTION
feat: no longer include office group query string parameter on installations table. it slows the request down considerably  and the data returned when that parameter is included is not used