### PR TITLE
fix: rplt-624 switch to desktop links so that AgencyCloud pops the urls in a new browser window

### DIFF
--- a/packages/marketplace-management/src/components/pages/__tests__/__snapshots__/marketplace-app.test.tsx.snap
+++ b/packages/marketplace-management/src/components/pages/__tests__/__snapshots__/marketplace-app.test.tsx.snap
@@ -420,8 +420,10 @@ exports[`MarketplaceAppPage should match a snapshot when has data 1`] = `
              
             <a
               href="https://foundations-documentation.reapit.cloud/platform-glossary/permissions"
+              rel="noopener noreferrer"
+              target="_blank"
             >
-              click here.
+              https://foundations-documentation.reapit.cloud/platform-glossary/permissions
             </a>
           </p>
           <h2
@@ -825,8 +827,10 @@ exports[`MarketplaceAppPage should match a snapshot when has data 1`] = `
            
           <a
             href="https://foundations-documentation.reapit.cloud/platform-glossary/permissions"
+            rel="noopener noreferrer"
+            target="_blank"
           >
-            click here.
+            https://foundations-documentation.reapit.cloud/platform-glossary/permissions
           </a>
         </p>
         <h2

--- a/packages/marketplace-management/src/components/ui/apps/__tests__/__snapshots__/app-pricing-permissions-section.test.tsx.snap
+++ b/packages/marketplace-management/src/components/ui/apps/__tests__/__snapshots__/app-pricing-permissions-section.test.tsx.snap
@@ -73,8 +73,10 @@ exports[`AppPricingPermissionsSection should match a snapshot for desktop 1`] = 
          
         <a
           href="https://foundations-documentation.reapit.cloud/platform-glossary/permissions"
+          rel="noopener noreferrer"
+          target="_blank"
         >
-          click here.
+          https://foundations-documentation.reapit.cloud/platform-glossary/permissions
         </a>
       </p>
     </div>
@@ -148,8 +150,10 @@ exports[`AppPricingPermissionsSection should match a snapshot for desktop 1`] = 
        
       <a
         href="https://foundations-documentation.reapit.cloud/platform-glossary/permissions"
+        rel="noopener noreferrer"
+        target="_blank"
       >
-        click here.
+        https://foundations-documentation.reapit.cloud/platform-glossary/permissions
       </a>
     </p>
   </div>,
@@ -294,8 +298,10 @@ exports[`AppPricingPermissionsSection should match a snapshot for has a pricing 
          
         <a
           href="https://foundations-documentation.reapit.cloud/platform-glossary/permissions"
+          rel="noopener noreferrer"
+          target="_blank"
         >
-          click here.
+          https://foundations-documentation.reapit.cloud/platform-glossary/permissions
         </a>
       </p>
     </div>
@@ -383,8 +389,10 @@ exports[`AppPricingPermissionsSection should match a snapshot for has a pricing 
        
       <a
         href="https://foundations-documentation.reapit.cloud/platform-glossary/permissions"
+        rel="noopener noreferrer"
+        target="_blank"
       >
-        click here.
+        https://foundations-documentation.reapit.cloud/platform-glossary/permissions
       </a>
     </p>
   </div>,
@@ -529,8 +537,10 @@ exports[`AppPricingPermissionsSection should match a snapshot for has a pricing 
          
         <a
           href="https://foundations-documentation.reapit.cloud/platform-glossary/permissions"
+          rel="noopener noreferrer"
+          target="_blank"
         >
-          click here.
+          https://foundations-documentation.reapit.cloud/platform-glossary/permissions
         </a>
       </p>
     </div>
@@ -618,8 +628,10 @@ exports[`AppPricingPermissionsSection should match a snapshot for has a pricing 
        
       <a
         href="https://foundations-documentation.reapit.cloud/platform-glossary/permissions"
+        rel="noopener noreferrer"
+        target="_blank"
       >
-        click here.
+        https://foundations-documentation.reapit.cloud/platform-glossary/permissions
       </a>
     </p>
   </div>,
@@ -750,8 +762,10 @@ exports[`AppPricingPermissionsSection should match a snapshot for not desktop 1`
          
         <a
           href="https://foundations-documentation.reapit.cloud/platform-glossary/permissions"
+          rel="noopener noreferrer"
+          target="_blank"
         >
-          click here.
+          https://foundations-documentation.reapit.cloud/platform-glossary/permissions
         </a>
       </p>
     </div>
@@ -825,8 +839,10 @@ exports[`AppPricingPermissionsSection should match a snapshot for not desktop 1`
        
       <a
         href="https://foundations-documentation.reapit.cloud/platform-glossary/permissions"
+        rel="noopener noreferrer"
+        target="_blank"
       >
-        click here.
+        https://foundations-documentation.reapit.cloud/platform-glossary/permissions
       </a>
     </p>
   </div>,

--- a/packages/marketplace-management/src/components/ui/apps/app-pricing-permissions-section.tsx
+++ b/packages/marketplace-management/src/components/ui/apps/app-pricing-permissions-section.tsx
@@ -1,6 +1,7 @@
 import { cx } from '@linaria/core'
 import { BodyText, Col, elMb11, elMt6, Grid, Subtitle } from '@reapit/elements'
 import { AppDetailModel, DesktopIntegrationTypeModel } from '@reapit/foundations-ts-definitions'
+import { AcProcessType, DesktopLink } from '@reapit/utils-react'
 import React from 'react'
 
 export interface AppPricingPermissionsProps {
@@ -93,7 +94,12 @@ const AppPricingPermissionsSection: React.FC<AppPricingPermissionsProps> = ({
         )}
         <BodyText hasGreyText className={cx(elMt6)}>
           For more detailed information about App permissions, please{' '}
-          <a href="https://foundations-documentation.reapit.cloud/platform-glossary/permissions">click here.</a>
+          <DesktopLink
+            uri="https://foundations-documentation.reapit.cloud/platform-glossary/permissions"
+            acProcess={AcProcessType.web}
+            target="_blank"
+            content="https://foundations-documentation.reapit.cloud/platform-glossary/permissions"
+          />
         </BodyText>
       </>
     </>

--- a/packages/marketplace/src/components/apps-detail/__tests__/__snapshots__/app-install-modal.test.tsx.snap
+++ b/packages/marketplace/src/components/apps-detail/__tests__/__snapshots__/app-install-modal.test.tsx.snap
@@ -126,10 +126,11 @@ exports[`AppInstallModalContent should match a snapshot where an org admin and d
            
           <a
             href="https://foundations-documentation.reapit.cloud/platform-glossary/permissions"
+            rel="noopener noreferrer"
+            target="_blank"
           >
-            click here
+            https://foundations-documentation.reapit.cloud/platform-glossary/permissions
           </a>
-          .
         </p>
       </div>
       <div
@@ -281,10 +282,11 @@ exports[`AppInstallModalContent should match a snapshot where an org admin and d
          
         <a
           href="https://foundations-documentation.reapit.cloud/platform-glossary/permissions"
+          rel="noopener noreferrer"
+          target="_blank"
         >
-          click here
+          https://foundations-documentation.reapit.cloud/platform-glossary/permissions
         </a>
-        .
       </p>
     </div>
     <div
@@ -493,10 +495,11 @@ exports[`AppInstallModalContent should match a snapshot where an org admin and w
            
           <a
             href="https://foundations-documentation.reapit.cloud/platform-glossary/permissions"
+            rel="noopener noreferrer"
+            target="_blank"
           >
-            click here
+            https://foundations-documentation.reapit.cloud/platform-glossary/permissions
           </a>
-          .
         </p>
       </div>
       <div
@@ -648,10 +651,11 @@ exports[`AppInstallModalContent should match a snapshot where an org admin and w
          
         <a
           href="https://foundations-documentation.reapit.cloud/platform-glossary/permissions"
+          rel="noopener noreferrer"
+          target="_blank"
         >
-          click here
+          https://foundations-documentation.reapit.cloud/platform-glossary/permissions
         </a>
-        .
       </p>
     </div>
     <div
@@ -838,10 +842,11 @@ exports[`AppInstallModalContent should match a snapshot where app is free 1`] = 
            
           <a
             href="https://foundations-documentation.reapit.cloud/platform-glossary/permissions"
+            rel="noopener noreferrer"
+            target="_blank"
           >
-            click here
+            https://foundations-documentation.reapit.cloud/platform-glossary/permissions
           </a>
-          .
         </p>
       </div>
       <div
@@ -971,10 +976,11 @@ exports[`AppInstallModalContent should match a snapshot where app is free 1`] = 
          
         <a
           href="https://foundations-documentation.reapit.cloud/platform-glossary/permissions"
+          rel="noopener noreferrer"
+          target="_blank"
         >
-          click here
+          https://foundations-documentation.reapit.cloud/platform-glossary/permissions
         </a>
-        .
       </p>
     </div>
     <div
@@ -1179,10 +1185,11 @@ exports[`AppInstallModalContent should match a snapshot where has off grouping, 
            
           <a
             href="https://foundations-documentation.reapit.cloud/platform-glossary/permissions"
+            rel="noopener noreferrer"
+            target="_blank"
           >
-            click here
+            https://foundations-documentation.reapit.cloud/platform-glossary/permissions
           </a>
-          .
         </p>
       </div>
       <div
@@ -1330,10 +1337,11 @@ exports[`AppInstallModalContent should match a snapshot where has off grouping, 
          
         <a
           href="https://foundations-documentation.reapit.cloud/platform-glossary/permissions"
+          rel="noopener noreferrer"
+          target="_blank"
         >
-          click here
+          https://foundations-documentation.reapit.cloud/platform-glossary/permissions
         </a>
-        .
       </p>
     </div>
     <div
@@ -1523,10 +1531,11 @@ exports[`AppInstallModalContent should match a snapshot where not free but no pr
            
           <a
             href="https://foundations-documentation.reapit.cloud/platform-glossary/permissions"
+            rel="noopener noreferrer"
+            target="_blank"
           >
-            click here
+            https://foundations-documentation.reapit.cloud/platform-glossary/permissions
           </a>
-          .
         </p>
       </div>
       <div
@@ -1659,10 +1668,11 @@ exports[`AppInstallModalContent should match a snapshot where not free but no pr
          
         <a
           href="https://foundations-documentation.reapit.cloud/platform-glossary/permissions"
+          rel="noopener noreferrer"
+          target="_blank"
         >
-          click here
+          https://foundations-documentation.reapit.cloud/platform-glossary/permissions
         </a>
-        .
       </p>
     </div>
     <div
@@ -1869,10 +1879,11 @@ exports[`AppInstallModalContent should match a snapshot where not off grouping, 
            
           <a
             href="https://foundations-documentation.reapit.cloud/platform-glossary/permissions"
+            rel="noopener noreferrer"
+            target="_blank"
           >
-            click here
+            https://foundations-documentation.reapit.cloud/platform-glossary/permissions
           </a>
-          .
         </p>
       </div>
       <div
@@ -2022,10 +2033,11 @@ exports[`AppInstallModalContent should match a snapshot where not off grouping, 
          
         <a
           href="https://foundations-documentation.reapit.cloud/platform-glossary/permissions"
+          rel="noopener noreferrer"
+          target="_blank"
         >
-          click here
+          https://foundations-documentation.reapit.cloud/platform-glossary/permissions
         </a>
-        .
       </p>
     </div>
     <div

--- a/packages/marketplace/src/components/apps-detail/__tests__/__snapshots__/apps-detail.test.tsx.snap
+++ b/packages/marketplace/src/components/apps-detail/__tests__/__snapshots__/apps-detail.test.tsx.snap
@@ -1144,10 +1144,11 @@ exports[`AppsDetail should match a snapshot when not installed 1`] = `
                  
                 <a
                   href="https://foundations-documentation.reapit.cloud/platform-glossary/permissions"
+                  rel="noopener noreferrer"
+                  target="_blank"
                 >
-                  click here
+                  https://foundations-documentation.reapit.cloud/platform-glossary/permissions
                 </a>
-                .
               </p>
             </div>
             <div
@@ -1644,10 +1645,11 @@ exports[`AppsDetail should match a snapshot when not installed 1`] = `
                
               <a
                 href="https://foundations-documentation.reapit.cloud/platform-glossary/permissions"
+                rel="noopener noreferrer"
+                target="_blank"
               >
-                click here
+                https://foundations-documentation.reapit.cloud/platform-glossary/permissions
               </a>
-              .
             </p>
           </div>
           <div
@@ -2193,10 +2195,11 @@ exports[`AppsDetail should match a snapshot with data 1`] = `
                  
                 <a
                   href="https://foundations-documentation.reapit.cloud/platform-glossary/permissions"
+                  rel="noopener noreferrer"
+                  target="_blank"
                 >
-                  click here
+                  https://foundations-documentation.reapit.cloud/platform-glossary/permissions
                 </a>
-                .
               </p>
             </div>
             <div
@@ -2676,10 +2679,11 @@ exports[`AppsDetail should match a snapshot with data 1`] = `
                
               <a
                 href="https://foundations-documentation.reapit.cloud/platform-glossary/permissions"
+                rel="noopener noreferrer"
+                target="_blank"
               >
-                click here
+                https://foundations-documentation.reapit.cloud/platform-glossary/permissions
               </a>
-              .
             </p>
           </div>
           <div

--- a/packages/marketplace/src/components/apps-detail/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/marketplace/src/components/apps-detail/__tests__/__snapshots__/index.test.tsx.snap
@@ -273,10 +273,11 @@ exports[`AppsDetailPage should match a snapshot 1`] = `
                  
                 <a
                   href="https://foundations-documentation.reapit.cloud/platform-glossary/permissions"
+                  rel="noopener noreferrer"
+                  target="_blank"
                 >
-                  click here
+                  https://foundations-documentation.reapit.cloud/platform-glossary/permissions
                 </a>
-                .
               </p>
             </div>
           </mock-styled.div>
@@ -553,10 +554,11 @@ exports[`AppsDetailPage should match a snapshot 1`] = `
                
               <a
                 href="https://foundations-documentation.reapit.cloud/platform-glossary/permissions"
+                rel="noopener noreferrer"
+                target="_blank"
               >
-                click here
+                https://foundations-documentation.reapit.cloud/platform-glossary/permissions
               </a>
-              .
             </p>
           </div>
         </mock-styled.div>

--- a/packages/marketplace/src/components/apps-detail/app-install-modal.tsx
+++ b/packages/marketplace/src/components/apps-detail/app-install-modal.tsx
@@ -202,7 +202,12 @@ export const AppInstallModalContent: FC<AppInstallModalContentProps> = ({
           ))}
           <BodyText className={cx(elMt6)} hasGreyText>
             For more detailed information about App permissions, please{' '}
-            <a href="https://foundations-documentation.reapit.cloud/platform-glossary/permissions">click here</a>.
+            <DesktopLink
+              uri="https://foundations-documentation.reapit.cloud/platform-glossary/permissions"
+              acProcess={AcProcessType.web}
+              target="_blank"
+              content="https://foundations-documentation.reapit.cloud/platform-glossary/permissions"
+            />
           </BodyText>
         </>
       </div>

--- a/packages/marketplace/src/components/apps-detail/apps-detail.tsx
+++ b/packages/marketplace/src/components/apps-detail/apps-detail.tsx
@@ -473,7 +473,12 @@ export const AppsDetail: FC = () => {
                 ))}
                 <BodyText className={cx(elMt6)} hasGreyText>
                   For more detailed information about App permissions, please{' '}
-                  <a href="https://foundations-documentation.reapit.cloud/platform-glossary/permissions">click here</a>.
+                  <DesktopLink
+                    uri="https://foundations-documentation.reapit.cloud/platform-glossary/permissions"
+                    acProcess={AcProcessType.web}
+                    target="_blank"
+                    content="https://foundations-documentation.reapit.cloud/platform-glossary/permissions"
+                  />
                 </BodyText>
               </div>
               {Boolean(desktopIntegrationTypeIds?.length) && (


### PR DESCRIPTION
- resolves issue with links not being opened in user's default browser when in desktop mode


