### PR TITLE
feat: add status filter to installations table

### DIFF
--- a/packages/admin-portal/src/components/installations/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/admin-portal/src/components/installations/__tests__/__snapshots__/index.test.tsx.snap
@@ -340,6 +340,62 @@ exports[`Installations should render component when loading 1`] = `
                 </div>
               </div>
             </div>
+            <div
+              class="mocked-styled-133 el-input-wrap"
+            >
+              <div
+                class="mocked-styled-40 el-input-group"
+              >
+                <label
+                  class="mocked-styled-41 el-label"
+                >
+                  Status
+                </label>
+                <div
+                  class="el-has-grey-bg el-toggle-radio-wrap"
+                >
+                  <input
+                    checked=""
+                    class="mocked-styled-127 el-toggle-radio"
+                    id="option-is-active"
+                    name="isInstalled"
+                    type="radio"
+                    value="true"
+                  />
+                  <label
+                    class="el-has-grey-bg el-toggle-radio-label"
+                    for="option-is-active"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <span
+                      class="mocked-styled-124 el-toggle-radio-item"
+                    >
+                      Active
+                    </span>
+                  </label>
+                  <input
+                    class="mocked-styled-127 el-toggle-radio"
+                    id="option-is-terminated"
+                    name="isInstalled"
+                    type="radio"
+                    value="false"
+                  />
+                  <label
+                    class="el-has-grey-bg el-toggle-radio-label"
+                    for="option-is-terminated"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <span
+                      class="mocked-styled-124 el-toggle-radio-item"
+                    >
+                      Terminated
+                    </span>
+                  </label>
+                </div>
+              </div>
+            </div>
           </div>
         </form>
         <div
@@ -708,6 +764,62 @@ exports[`Installations should render component when loading 1`] = `
                     class="mocked-styled-124 el-toggle-radio-item"
                   >
                     Free
+                  </span>
+                </label>
+              </div>
+            </div>
+          </div>
+          <div
+            class="mocked-styled-133 el-input-wrap"
+          >
+            <div
+              class="mocked-styled-40 el-input-group"
+            >
+              <label
+                class="mocked-styled-41 el-label"
+              >
+                Status
+              </label>
+              <div
+                class="el-has-grey-bg el-toggle-radio-wrap"
+              >
+                <input
+                  checked=""
+                  class="mocked-styled-127 el-toggle-radio"
+                  id="option-is-active"
+                  name="isInstalled"
+                  type="radio"
+                  value="true"
+                />
+                <label
+                  class="el-has-grey-bg el-toggle-radio-label"
+                  for="option-is-active"
+                  role="button"
+                  tabindex="0"
+                >
+                  <span
+                    class="mocked-styled-124 el-toggle-radio-item"
+                  >
+                    Active
+                  </span>
+                </label>
+                <input
+                  class="mocked-styled-127 el-toggle-radio"
+                  id="option-is-terminated"
+                  name="isInstalled"
+                  type="radio"
+                  value="false"
+                />
+                <label
+                  class="el-has-grey-bg el-toggle-radio-label"
+                  for="option-is-terminated"
+                  role="button"
+                  tabindex="0"
+                >
+                  <span
+                    class="mocked-styled-124 el-toggle-radio-item"
+                  >
+                    Terminated
                   </span>
                 </label>
               </div>
@@ -1147,6 +1259,62 @@ exports[`Installations should render component with data 1`] = `
                       class="mocked-styled-124 el-toggle-radio-item"
                     >
                       Free
+                    </span>
+                  </label>
+                </div>
+              </div>
+            </div>
+            <div
+              class="mocked-styled-133 el-input-wrap"
+            >
+              <div
+                class="mocked-styled-40 el-input-group"
+              >
+                <label
+                  class="mocked-styled-41 el-label"
+                >
+                  Status
+                </label>
+                <div
+                  class="el-has-grey-bg el-toggle-radio-wrap"
+                >
+                  <input
+                    checked=""
+                    class="mocked-styled-127 el-toggle-radio"
+                    id="option-is-active"
+                    name="isInstalled"
+                    type="radio"
+                    value="true"
+                  />
+                  <label
+                    class="el-has-grey-bg el-toggle-radio-label"
+                    for="option-is-active"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <span
+                      class="mocked-styled-124 el-toggle-radio-item"
+                    >
+                      Active
+                    </span>
+                  </label>
+                  <input
+                    class="mocked-styled-127 el-toggle-radio"
+                    id="option-is-terminated"
+                    name="isInstalled"
+                    type="radio"
+                    value="false"
+                  />
+                  <label
+                    class="el-has-grey-bg el-toggle-radio-label"
+                    for="option-is-terminated"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <span
+                      class="mocked-styled-124 el-toggle-radio-item"
+                    >
+                      Terminated
                     </span>
                   </label>
                 </div>
@@ -1869,6 +2037,62 @@ exports[`Installations should render component with data 1`] = `
                     class="mocked-styled-124 el-toggle-radio-item"
                   >
                     Free
+                  </span>
+                </label>
+              </div>
+            </div>
+          </div>
+          <div
+            class="mocked-styled-133 el-input-wrap"
+          >
+            <div
+              class="mocked-styled-40 el-input-group"
+            >
+              <label
+                class="mocked-styled-41 el-label"
+              >
+                Status
+              </label>
+              <div
+                class="el-has-grey-bg el-toggle-radio-wrap"
+              >
+                <input
+                  checked=""
+                  class="mocked-styled-127 el-toggle-radio"
+                  id="option-is-active"
+                  name="isInstalled"
+                  type="radio"
+                  value="true"
+                />
+                <label
+                  class="el-has-grey-bg el-toggle-radio-label"
+                  for="option-is-active"
+                  role="button"
+                  tabindex="0"
+                >
+                  <span
+                    class="mocked-styled-124 el-toggle-radio-item"
+                  >
+                    Active
+                  </span>
+                </label>
+                <input
+                  class="mocked-styled-127 el-toggle-radio"
+                  id="option-is-terminated"
+                  name="isInstalled"
+                  type="radio"
+                  value="false"
+                />
+                <label
+                  class="el-has-grey-bg el-toggle-radio-label"
+                  for="option-is-terminated"
+                  role="button"
+                  tabindex="0"
+                >
+                  <span
+                    class="mocked-styled-124 el-toggle-radio-item"
+                  >
+                    Terminated
                   </span>
                 </label>
               </div>

--- a/packages/admin-portal/src/components/installations/index.tsx
+++ b/packages/admin-portal/src/components/installations/index.tsx
@@ -35,23 +35,20 @@ export interface InstallationFilters {
   installedDateFrom?: string
   installedDateTo?: string
   appIds?: string
-  isInstalled?: 'ALL' | 'INSTALLED' | 'UNINSTALLED'
   companyName?: string
   clientId?: string
   isChargedConsumption?: string
+  isInstalled?: string
 }
 
 const defaultValues: InstallationFilters = {
   appIds: '',
-  isInstalled: 'ALL',
+  isInstalled: 'true',
 }
 
 export const formatFilters = (installationsFilters: InstallationFilters) => {
   const { installedDateTo, installedDateFrom, isInstalled, appIds, clientId, companyName, isChargedConsumption } =
     installationsFilters
-
-  const isInstaledQuery =
-    isInstalled === 'INSTALLED' ? { isInstalled: true } : isInstalled === 'UNINSTALLED' ? { isInstalled: true } : {}
 
   const appIdQuery = appIds ? { appId: appIds.split(',').filter(Boolean) } : {}
   const clientIdQuery = clientId ? { clientId } : {}
@@ -61,7 +58,7 @@ export const formatFilters = (installationsFilters: InstallationFilters) => {
     installedDateTo: installedDateTo ? dayjs(installedDateTo).format('YYYY-MM-DDTHH:mm:ss') : undefined,
     installedDateFrom: installedDateFrom ? dayjs(installedDateFrom).format('YYYY-MM-DDTHH:mm:ss') : undefined,
     isChargedConsumption,
-    ...isInstaledQuery,
+    isInstalled,
     ...appIdQuery,
     ...clientIdQuery,
     ...companyNameQuery,
@@ -196,6 +193,29 @@ export const Installations: FC = () => {
                     text: 'Free',
                     isChecked: false,
                   },
+                ]}
+              />
+            </InputGroup>
+          </InputWrap>
+          <InputWrap>
+            <InputGroup>
+              <Label>Status</Label>
+              <ToggleRadio
+                {...register('isInstalled')}
+                hasGreyBg
+                options={[
+                  {
+                    id: 'option-is-active',
+                    value: 'true',
+                    text: 'Active',
+                    isChecked: true,
+                  },
+                  {
+                    id: 'option-is-terminated',
+                    value: 'false',
+                    text: 'Terminated',
+                    isChecked: false,
+                  }
                 ]}
               />
             </InputGroup>

--- a/packages/admin-portal/src/components/installations/index.tsx
+++ b/packages/admin-portal/src/components/installations/index.tsx
@@ -215,7 +215,7 @@ export const Installations: FC = () => {
                     value: 'false',
                     text: 'Terminated',
                     isChecked: false,
-                  }
+                  },
                 ]}
               />
             </InputGroup>


### PR DESCRIPTION
- adds a status filter to the installations table. it's often the case that terminated installations are irrelevant
![image](https://github.com/user-attachments/assets/9769187e-0bfe-4de5-9098-c3db1e35d449)

@HollyJoyPhillips can you tag the ticket please once you've logged it

