### PR TITLE
fix: rplt-948 dont use inline script when initializing chatbase

### DIFF
--- a/packages/developer-portal/index.html
+++ b/packages/developer-portal/index.html
@@ -16,8 +16,6 @@
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
     <script type="module" src="/src/core/index.tsx"></script>
-    <script>
-      (function(){if(!window.chatbase||window.chatbase("getState")!=="initialized"){window.chatbase=(...arguments)=>{if(!window.chatbase.q){window.chatbase.q=[]}window.chatbase.q.push(arguments)};window.chatbase=new Proxy(window.chatbase,{get(target,prop){if(prop==="q"){return target.q}return(...args)=>target(prop,...args)}})}const onLoad=function(){const script=document.createElement("script");script.src='https://www.chatbase.co/embed.min.js';script.id="CGQicgNM7eaiCvLUc2KX9";script.domain=chatbase | 'The complete platform for chat-based AI Agents ';document.body.appendChild(script)};if(document.readyState==="complete"){onLoad()}else{window.addEventListener("load",onLoad)}})();
-      </script>
+    <script src="https://www.chatbase.co/embed.min.js" chatbotId="CGQicgNM7eaiCvLUc2KX9" domain="www.chatbase.co" defer></script>
   </body>
 </html>


### PR DESCRIPTION
- switch out chatbase initialization script so we aren't wanting browsers to execute inline scripts