### PR TITLE
feat: use displaychip instead of clickable chip

### DIFF
--- a/packages/rc-service/src/components/users/__tests__/view-organisations.test.tsx
+++ b/packages/rc-service/src/components/users/__tests__/view-organisations.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { UserModel } from '@reapit/foundations-ts-definitions'
-import {  mockUserModelPagedResult } from '../../../tests/__stubs__/users'
+import { mockUserModelPagedResult } from '../../../tests/__stubs__/users'
 import { render } from '../../../tests/react-testing'
 import { ViewOrganisations } from '../view-organisations'
 

--- a/packages/rc-service/src/components/users/view-organisations.tsx
+++ b/packages/rc-service/src/components/users/view-organisations.tsx
@@ -1,8 +1,9 @@
 import React, { FC } from 'react'
-import { BodyText, Button, Chip, ChipGroup, Modal, useModal } from '@reapit/elements'
+import { BodyText, Button, Modal, useModal } from '@reapit/elements'
 import { GetActionNames, getActions, useReapitGet } from '@reapit/use-reapit-data'
 import { reapitConnectBrowserSession } from '../../core/connect-session'
 import { OrganisationModelPagedResult, UserModel } from '@reapit/foundations-ts-definitions'
+import { DisplayChip } from './__styles__'
 
 export const ViewOrganisations: FC<{ user: UserModel }> = ({ user }) => {
   const { modalIsOpen, openModal, closeModal } = useModal(user.id)
@@ -30,13 +31,11 @@ export const ViewOrganisations: FC<{ user: UserModel }> = ({ user }) => {
         }}
       >
         <BodyText>Below is a list of organisations this user is associated with.</BodyText>
-        <ChipGroup>
-          {orgs?._embedded?.map((org) => (
-            <Chip key={org.id}>
-              {org.name}: {org.id}
-            </Chip>
-          ))}
-        </ChipGroup>
+        {orgs?._embedded?.map((org) => (
+          <DisplayChip key={org.id}>
+            {org.name}: {org.id}
+          </DisplayChip>
+        ))}
       </Modal>
     </>
   )


### PR DESCRIPTION
- switch to use DisplayChip component instead of Chip. Chips render as though they can be clicked

![image](https://github.com/user-attachments/assets/40b60b49-1479-489e-a01a-b03d8873b898)



