### PR TITLE
feat: rplt-1043 sort lists on analytics tab alphabetically

### DIFF
--- a/packages/developer-portal/src/components/analytics/page/__tests__/__snapshots__/controls.test.tsx.snap
+++ b/packages/developer-portal/src/components/analytics/page/__tests__/__snapshots__/controls.test.tsx.snap
@@ -238,14 +238,14 @@ exports[`Controls should match a snapshot 1`] = `
                     None selected
                   </option>
                   <option
-                    value="RES"
-                  >
-                    Reapit Sales  (RES)
-                  </option>
-                  <option
                     value="MXX"
                   >
                     Foo Bar  (MXX)
+                  </option>
+                  <option
+                    value="RES"
+                  >
+                    Reapit Sales  (RES)
                   </option>
                 </select>
                 <label
@@ -494,14 +494,14 @@ exports[`Controls should match a snapshot 1`] = `
                   None selected
                 </option>
                 <option
-                  value="RES"
-                >
-                  Reapit Sales  (RES)
-                </option>
-                <option
                   value="MXX"
                 >
                   Foo Bar  (MXX)
+                </option>
+                <option
+                  value="RES"
+                >
+                  Reapit Sales  (RES)
                 </option>
               </select>
               <label

--- a/packages/developer-portal/src/components/analytics/page/controls.tsx
+++ b/packages/developer-portal/src/components/analytics/page/controls.tsx
@@ -44,6 +44,9 @@ export const handleInstallationsToOptions = (installations?: Marketplace.Install
 
   const options: MultiSelectOption[] = [...new Set(customers)].map((customer) => JSON.parse(customer))
 
+  // Sort options alphabetically by name before rendering
+  options.sort((a, b) => a.name.localeCompare(b.name))
+
   return options
 }
 
@@ -129,11 +132,13 @@ export const Controls: FC = () => {
                 <option key="default-option" value="">
                   None selected
                 </option>
-                {apps?.data?.map(({ name, id }: Marketplace.AppSummaryModel) => (
-                  <option key={id} value={id}>
-                    {name}
-                  </option>
-                ))}
+                {apps?.data
+                  ?.sort((a, b) => (a.name || '').localeCompare(b.name || ''))
+                  .map(({ name, id }: Marketplace.AppSummaryModel) => (
+                    <option key={id} value={id}>
+                      {name}
+                    </option>
+                  ))}
               </Select>
               <Label>App</Label>
             </InputGroup>


### PR DESCRIPTION
- Client and App lists will now be sorted alphabetically before rendering to provide a better experience trying to find certain apps

![image](https://github.com/user-attachments/assets/9a0cc23f-a134-48e5-b80f-958bedc6dc42)
