### PR TITLE
feat: rplt-1058 update documentation links

### DIFF
--- a/packages/marketplace-management/src/components/ui/apps/__tests__/__snapshots__/app-pricing-permissions-section.test.tsx.snap
+++ b/packages/marketplace-management/src/components/ui/apps/__tests__/__snapshots__/app-pricing-permissions-section.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`AppPricingPermissionsSection should match a snapshot for desktop 1`] = 
         For more information regarding Desktop Integration types, please
          
         <a
-          href="agencycloud://process/webpage?url=https://marketplace-documentation.reapit.cloud/integration-types"
+          href="agencycloud://process/webpage?url=https://reapit.atlassian.net/wiki/spaces/RW/pages/2875359379/Desktop+integration+types+AppMarket"
           rel="noopener noreferrer"
           target="_blank"
         >
@@ -99,7 +99,7 @@ exports[`AppPricingPermissionsSection should match a snapshot for desktop 1`] = 
       For more information regarding Desktop Integration types, please
        
       <a
-        href="agencycloud://process/webpage?url=https://marketplace-documentation.reapit.cloud/integration-types"
+        href="agencycloud://process/webpage?url=https://reapit.atlassian.net/wiki/spaces/RW/pages/2875359379/Desktop+integration+types+AppMarket"
         rel="noopener noreferrer"
         target="_blank"
       >
@@ -234,7 +234,7 @@ exports[`AppPricingPermissionsSection should match a snapshot for has a pricing 
         For more information regarding Desktop Integration types, please
          
         <a
-          href="agencycloud://process/webpage?url=https://marketplace-documentation.reapit.cloud/integration-types"
+          href="agencycloud://process/webpage?url=https://reapit.atlassian.net/wiki/spaces/RW/pages/2875359379/Desktop+integration+types+AppMarket"
           rel="noopener noreferrer"
           target="_blank"
         >
@@ -326,7 +326,7 @@ exports[`AppPricingPermissionsSection should match a snapshot for has a pricing 
       For more information regarding Desktop Integration types, please
        
       <a
-        href="agencycloud://process/webpage?url=https://marketplace-documentation.reapit.cloud/integration-types"
+        href="agencycloud://process/webpage?url=https://reapit.atlassian.net/wiki/spaces/RW/pages/2875359379/Desktop+integration+types+AppMarket"
         rel="noopener noreferrer"
         target="_blank"
       >
@@ -475,7 +475,7 @@ exports[`AppPricingPermissionsSection should match a snapshot for has a pricing 
         For more information regarding Desktop Integration types, please
          
         <a
-          href="https://marketplace-documentation.reapit.cloud/integration-types"
+          href="https://reapit.atlassian.net/wiki/spaces/RW/pages/2875359379/Desktop+integration+types+AppMarket"
           rel="noopener noreferrer"
           target="_blank"
         >
@@ -567,7 +567,7 @@ exports[`AppPricingPermissionsSection should match a snapshot for has a pricing 
       For more information regarding Desktop Integration types, please
        
       <a
-        href="https://marketplace-documentation.reapit.cloud/integration-types"
+        href="https://reapit.atlassian.net/wiki/spaces/RW/pages/2875359379/Desktop+integration+types+AppMarket"
         rel="noopener noreferrer"
         target="_blank"
       >
@@ -716,7 +716,7 @@ exports[`AppPricingPermissionsSection should match a snapshot for not desktop 1`
         For more information regarding Desktop Integration types, please
          
         <a
-          href="https://marketplace-documentation.reapit.cloud/integration-types"
+          href="https://reapit.atlassian.net/wiki/spaces/RW/pages/2875359379/Desktop+integration+types+AppMarket"
           rel="noopener noreferrer"
           target="_blank"
         >
@@ -794,7 +794,7 @@ exports[`AppPricingPermissionsSection should match a snapshot for not desktop 1`
       For more information regarding Desktop Integration types, please
        
       <a
-        href="https://marketplace-documentation.reapit.cloud/integration-types"
+        href="https://reapit.atlassian.net/wiki/spaces/RW/pages/2875359379/Desktop+integration+types+AppMarket"
         rel="noopener noreferrer"
         target="_blank"
       >

--- a/packages/marketplace-management/src/components/ui/apps/app-pricing-permissions-section.tsx
+++ b/packages/marketplace-management/src/components/ui/apps/app-pricing-permissions-section.tsx
@@ -12,8 +12,8 @@ export interface AppPricingPermissionsProps {
 
 export const getDocs = (isDesktop: boolean) => {
   return isDesktop
-    ? 'agencycloud://process/webpage?url=https://marketplace-documentation.reapit.cloud/integration-types'
-    : 'https://marketplace-documentation.reapit.cloud/integration-types'
+    ? 'agencycloud://process/webpage?url=https://reapit.atlassian.net/wiki/spaces/RW/pages/2875359379/Desktop+integration+types+AppMarket'
+    : 'https://reapit.atlassian.net/wiki/spaces/RW/pages/2875359379/Desktop+integration+types+AppMarket'
 }
 
 export const getPricing = (isDesktop: boolean, pricingUrl: string) => {

--- a/packages/marketplace-management/src/constants/api.ts
+++ b/packages/marketplace-management/src/constants/api.ts
@@ -17,5 +17,7 @@ export const URLS = {
   INSTALLATIONS: '/marketplace/installations',
 }
 
-export const GLOSSARY_USER_ROLES_URL = 'https://managementapp-foundations.reapit.cloud/users'
-export const OFFICE_GROUPS_DOCS_URL = 'https://managementapp-foundations.reapit.cloud/offices#to-create-an-office-group'
+export const GLOSSARY_USER_ROLES_URL =
+  'https://reapit.atlassian.net/wiki/spaces/RW/pages/2873884778/User+group+types+add+remove+users+from+groups+Marketplace+Management+app'
+export const OFFICE_GROUPS_DOCS_URL =
+  'https://reapit.atlassian.net/wiki/spaces/RW/pages/2873884787/Create+edit+office+groups+Marketplace+Management+app'

--- a/packages/marketplace/src/components/apps-detail/__tests__/__snapshots__/app-install-modal.test.tsx.snap
+++ b/packages/marketplace/src/components/apps-detail/__tests__/__snapshots__/app-install-modal.test.tsx.snap
@@ -52,7 +52,7 @@ exports[`AppInstallModalContent should match a snapshot where an org admin and d
           For more information regarding Desktop Integration types, please
            
           <a
-            href="https://marketplace-documentation.reapit.cloud/integration-types"
+            href="https://reapit.atlassian.net/wiki/spaces/RW/pages/2875359379/Desktop+integration+types+AppMarket"
             rel="noopener noreferrer"
             target="_blank"
           >
@@ -209,7 +209,7 @@ exports[`AppInstallModalContent should match a snapshot where an org admin and d
         For more information regarding Desktop Integration types, please
          
         <a
-          href="https://marketplace-documentation.reapit.cloud/integration-types"
+          href="https://reapit.atlassian.net/wiki/spaces/RW/pages/2875359379/Desktop+integration+types+AppMarket"
           rel="noopener noreferrer"
           target="_blank"
         >
@@ -423,7 +423,7 @@ exports[`AppInstallModalContent should match a snapshot where an org admin and w
           For more information regarding Desktop Integration types, please
            
           <a
-            href="https://marketplace-documentation.reapit.cloud/integration-types"
+            href="https://reapit.atlassian.net/wiki/spaces/RW/pages/2875359379/Desktop+integration+types+AppMarket"
             rel="noopener noreferrer"
             target="_blank"
           >
@@ -580,7 +580,7 @@ exports[`AppInstallModalContent should match a snapshot where an org admin and w
         For more information regarding Desktop Integration types, please
          
         <a
-          href="https://marketplace-documentation.reapit.cloud/integration-types"
+          href="https://reapit.atlassian.net/wiki/spaces/RW/pages/2875359379/Desktop+integration+types+AppMarket"
           rel="noopener noreferrer"
           target="_blank"
         >
@@ -792,7 +792,7 @@ exports[`AppInstallModalContent should match a snapshot where app is free 1`] = 
           For more information regarding Desktop Integration types, please
            
           <a
-            href="https://marketplace-documentation.reapit.cloud/integration-types"
+            href="https://reapit.atlassian.net/wiki/spaces/RW/pages/2875359379/Desktop+integration+types+AppMarket"
             rel="noopener noreferrer"
             target="_blank"
           >
@@ -927,7 +927,7 @@ exports[`AppInstallModalContent should match a snapshot where app is free 1`] = 
         For more information regarding Desktop Integration types, please
          
         <a
-          href="https://marketplace-documentation.reapit.cloud/integration-types"
+          href="https://reapit.atlassian.net/wiki/spaces/RW/pages/2875359379/Desktop+integration+types+AppMarket"
           rel="noopener noreferrer"
           target="_blank"
         >
@@ -1117,7 +1117,7 @@ exports[`AppInstallModalContent should match a snapshot where has off grouping, 
           For more information regarding Desktop Integration types, please
            
           <a
-            href="https://marketplace-documentation.reapit.cloud/integration-types"
+            href="https://reapit.atlassian.net/wiki/spaces/RW/pages/2875359379/Desktop+integration+types+AppMarket"
             rel="noopener noreferrer"
             target="_blank"
           >
@@ -1270,7 +1270,7 @@ exports[`AppInstallModalContent should match a snapshot where has off grouping, 
         For more information regarding Desktop Integration types, please
          
         <a
-          href="https://marketplace-documentation.reapit.cloud/integration-types"
+          href="https://reapit.atlassian.net/wiki/spaces/RW/pages/2875359379/Desktop+integration+types+AppMarket"
           rel="noopener noreferrer"
           target="_blank"
         >
@@ -1482,7 +1482,7 @@ exports[`AppInstallModalContent should match a snapshot where not free but no pr
           For more information regarding Desktop Integration types, please
            
           <a
-            href="https://marketplace-documentation.reapit.cloud/integration-types"
+            href="https://reapit.atlassian.net/wiki/spaces/RW/pages/2875359379/Desktop+integration+types+AppMarket"
             rel="noopener noreferrer"
             target="_blank"
           >
@@ -1620,7 +1620,7 @@ exports[`AppInstallModalContent should match a snapshot where not free but no pr
         For more information regarding Desktop Integration types, please
          
         <a
-          href="https://marketplace-documentation.reapit.cloud/integration-types"
+          href="https://reapit.atlassian.net/wiki/spaces/RW/pages/2875359379/Desktop+integration+types+AppMarket"
           rel="noopener noreferrer"
           target="_blank"
         >
@@ -1815,7 +1815,7 @@ exports[`AppInstallModalContent should match a snapshot where not off grouping, 
           For more information regarding Desktop Integration types, please
            
           <a
-            href="https://marketplace-documentation.reapit.cloud/integration-types"
+            href="https://reapit.atlassian.net/wiki/spaces/RW/pages/2875359379/Desktop+integration+types+AppMarket"
             rel="noopener noreferrer"
             target="_blank"
           >
@@ -1970,7 +1970,7 @@ exports[`AppInstallModalContent should match a snapshot where not off grouping, 
         For more information regarding Desktop Integration types, please
          
         <a
-          href="https://marketplace-documentation.reapit.cloud/integration-types"
+          href="https://reapit.atlassian.net/wiki/spaces/RW/pages/2875359379/Desktop+integration+types+AppMarket"
           rel="noopener noreferrer"
           target="_blank"
         >

--- a/packages/marketplace/src/components/apps-detail/app-install-modal.tsx
+++ b/packages/marketplace/src/components/apps-detail/app-install-modal.tsx
@@ -146,7 +146,7 @@ export const AppInstallModalContent: FC<AppInstallModalContentProps> = ({
               For more information regarding Desktop Integration types, please{' '}
               <DesktopLink
                 onClick={trackReadDocs}
-                uri="https://marketplace-documentation.reapit.cloud/integration-types"
+                uri="https://reapit.atlassian.net/wiki/spaces/RW/pages/2875359379/Desktop+integration+types+AppMarket"
                 acProcess={AcProcessType.web}
                 target="_blank"
                 content="click here"

--- a/packages/marketplace/src/components/apps-support/index.tsx
+++ b/packages/marketplace/src/components/apps-support/index.tsx
@@ -64,7 +64,12 @@ export const AppsSupportPage: FC = () => {
         <SmallText hasGreyText>
           In addition we have provided comprehensive documentation on using the AppMarket at the below link.
         </SmallText>
-        <Button onClick={openNewPage('https://marketplace-documentation.reapit.cloud/')} intent="neutral">
+        <Button
+          onClick={openNewPage(
+            'https://reapit.atlassian.net/wiki/spaces/RW/pages/2875523105/Use+AppMarket+to+browse+install+uninstall+apps',
+          )}
+          intent="neutral"
+        >
           View Docs
         </Button>
       </SecondaryNavContainer>

--- a/packages/marketplace/src/components/settings/settings-installed.tsx
+++ b/packages/marketplace/src/components/settings/settings-installed.tsx
@@ -185,7 +185,14 @@ export const SettingsInstalled: FC = () => {
         The table below gives you the information about Reapit AppMarket apps and integrations you have installed
         currently or previously. In addition, you can uninstall apps for all users of your organisation by using the
         call to action on each row. For more information on the installations table{' '}
-        <a onClick={openNewPage('https://marketplace-documentation.reapit.cloud/#uninstalling-an-app')}>see here</a>.
+        <a
+          onClick={openNewPage(
+            'https://reapit.atlassian.net/wiki/spaces/RW/pages/2875523105/Use+AppMarket+to+browse+install+uninstall+apps#Uninstall-an-app',
+          )}
+        >
+          see here
+        </a>
+        .
       </BodyText>
       <FilterForm setInstallationsFilters={setInstallationsFilters} />
       {installationsLoading ? (

--- a/packages/rc-service/src/core/private-route-wrapper.tsx
+++ b/packages/rc-service/src/core/private-route-wrapper.tsx
@@ -62,7 +62,12 @@ export const PrivateRouteWrapper: FC<PropsWithChildren> = ({ children }) => {
           <SmallText tag="p" hasSectionMargin hasGreyText className={elMt5}>
             Should you encounter an issue or need support, please use the &apos;Help&apos; button below.
           </SmallText>
-          <Button intent="neutral" onClick={openNewPage('https://rcservice-documentation.reapit.cloud/')}>
+          <Button
+            intent="neutral"
+            onClick={openNewPage(
+              'https://reapit.atlassian.net/wiki/spaces/FOUN/pages/2874114065/Reapit+Connect+Service+App',
+            )}
+          >
             Help
           </Button>
         </SecondaryNavContainer>


### PR DESCRIPTION
- Updates documentation links to no longer use GIthub but to use public Reapit Knowledgebase (or internal confluence space for internal applications). This is due to a billing change at Gitbook which makes it too expensive.


