### PR TITLE
ci: update token permissions in production workflow

### DIFF
--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -21,7 +21,7 @@ env:
   DEVOPS_DEPLOYER_PAT: ${{ secrets.DEVOPS_DEPLOYER_PAT }}
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:


### PR DESCRIPTION
- Updates github token permissions so that version bump commit can be written without needing to use a PAT
