### PR TITLE
feat: Set login link to first product when user has multiple products

### DIFF
--- a/packages/cognito-custom-mail-lambda/src/mailer/custom-mailer.ts
+++ b/packages/cognito-custom-mail-lambda/src/mailer/custom-mailer.ts
@@ -44,7 +44,7 @@ const getConfirmRegistrationUrl = async (emailAddress: string) => {
     return confirmRegistrationUrl
   }
   const user: UserModel = await res.json()
-  if (user.products.length === 1) {
+  if (user.products.length > 0) {
     const productId = user.products[0].id
     if (productId === 'agentbox') return agentboxUrl
     if (productId === 'agentpoint') return agentpointUrl


### PR DESCRIPTION
- Previously returned override product URL only when user has single product, otherwise defaulted to UK marketplace
- Now if multiple products are found, uses the first one in the collection