### PR TITLE
fix: rplt-1210 sort padding on select role screen

### DIFF
--- a/packages/developer-portal/src/components/login/__tests__/__snapshots__/select-role.test.tsx.snap
+++ b/packages/developer-portal/src/components/login/__tests__/__snapshots__/select-role.test.tsx.snap
@@ -521,7 +521,7 @@ exports[`AppTypeOptionsContent should match a snapshot 1`] = `
                 <div
                   class="el-text-base el-small-text el-has-grey-text el-has-no-margin"
                 >
-                  Existing Reapit CRM subscriber
+                  Estate agency with an existing Reapit CRM subscription
                 </div>
               </div>
             </div>
@@ -1217,7 +1217,7 @@ exports[`AppTypeOptionsContent should match a snapshot 1`] = `
               <div
                 class="el-text-base el-small-text el-has-grey-text el-has-no-margin"
               >
-                Existing Reapit CRM subscriber
+                Estate agency with an existing Reapit CRM subscription
               </div>
             </div>
           </div>

--- a/packages/developer-portal/src/components/login/select-role.tsx
+++ b/packages/developer-portal/src/components/login/select-role.tsx
@@ -55,7 +55,7 @@ export const SelectRolePage: FC = () => {
             <FlexContainer isFlexJustifyCenter isFlexColumn>
               <BodyText>Existing Customer</BodyText>
               <SmallText tag="div" hasGreyText hasNoMargin>
-                Existing Reapit CRM subscriber
+                Estate agency with an existing Reapit CRM subscription
               </SmallText>
             </FlexContainer>
           </FlexContainer>


### PR DESCRIPTION
# Pull request checklist

**Detail as per issue below (required):**
Fixes slight spacing issue with the select-role screen. Have changed the text so it drops onto two lines like the other panels as it was easier than messing about with the layout components

Before
<img width="428" height="548" alt="image" src="https://github.com/user-attachments/assets/dddf6507-cdb8-4d54-9a04-370766fd387e" />

After
<img width="504" height="653" alt="image" src="https://github.com/user-attachments/assets/0e6cba6e-0578-4e8b-b0ed-19fd6db7f62b" />


fixes: #RPLT-1210


